### PR TITLE
ubuntu 22.04 LTS build fix

### DIFF
--- a/guests/linux/buildroot/aarch64.config
+++ b/guests/linux/buildroot/aarch64.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2020.11.3 Configuration
+# Buildroot 2022.02.2 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -46,6 +46,7 @@ BR2_aarch64=y
 # BR2_xtensa is not set
 BR2_ARCH_HAS_TOOLCHAIN_BUILDROOT=y
 BR2_ARCH="aarch64"
+BR2_NORMALIZED_ARCH="arm64"
 BR2_ENDIAN="LITTLE"
 BR2_GCC_TARGET_ABI="lp64"
 BR2_GCC_TARGET_CPU="cortex-a53"
@@ -126,6 +127,7 @@ BR2_GIT="git"
 BR2_CVS="cvs"
 BR2_LOCALFILES="cp"
 BR2_SCP="scp"
+BR2_SFTP="sftp"
 BR2_HG="hg"
 BR2_ZCAT="gzip -d -c"
 BR2_BZCAT="bzcat"
@@ -148,6 +150,7 @@ BR2_CPAN_MIRROR="http://cpan.metacpan.org"
 BR2_JLEVEL=0
 # BR2_CCACHE is not set
 # BR2_ENABLE_DEBUG is not set
+# BR2_ENABLE_RUNTIME_DEBUG is not set
 BR2_STRIP_strip=y
 BR2_STRIP_EXCLUDE_FILES=""
 BR2_STRIP_EXCLUDE_DIRS=""
@@ -175,6 +178,7 @@ BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 #
 # Security Hardening Options
 #
+BR2_PIC_PIE_ARCH_SUPPORTS=y
 # BR2_PIC_PIE is not set
 
 #
@@ -183,6 +187,7 @@ BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 BR2_RELRO_NONE=y
 # BR2_RELRO_PARTIAL is not set
 # BR2_RELRO_FULL is not set
+BR2_FORTIFY_SOURCE_ARCH_SUPPORTS=y
 
 #
 # Fortify Source needs a glibc toolchain and optimization
@@ -214,13 +219,13 @@ BR2_TOOLCHAIN_BUILDROOT_LIBC="uclibc"
 # BR2_KERNEL_HEADERS_4_14 is not set
 # BR2_KERNEL_HEADERS_4_19 is not set
 # BR2_KERNEL_HEADERS_5_4 is not set
-# BR2_KERNEL_HEADERS_5_8 is not set
-BR2_KERNEL_HEADERS_5_9=y
+# BR2_KERNEL_HEADERS_5_10 is not set
+BR2_KERNEL_HEADERS_5_15=y
+# BR2_KERNEL_HEADERS_5_16 is not set
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_KERNEL_HEADERS_LATEST=y
-BR2_DEFAULT_KERNEL_HEADERS="5.9.16"
+BR2_DEFAULT_KERNEL_HEADERS="5.15.39"
 BR2_PACKAGE_LINUX_HEADERS=y
 
 #
@@ -242,19 +247,19 @@ BR2_UCLIBC_INSTALL_UTILS=y
 #
 BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
 BR2_BINUTILS_VERSION_2_32_X=y
-# BR2_BINUTILS_VERSION_2_33_X is not set
-# BR2_BINUTILS_VERSION_2_34_X is not set
 # BR2_BINUTILS_VERSION_2_35_X is not set
+# BR2_BINUTILS_VERSION_2_36_X is not set
+# BR2_BINUTILS_VERSION_2_37_X is not set
 BR2_BINUTILS_VERSION="2.32"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 
 #
 # GCC Options
 #
-BR2_GCC_VERSION_8_X=y
 # BR2_GCC_VERSION_9_X is not set
-# BR2_GCC_VERSION_10_X is not set
-BR2_GCC_VERSION="8.4.0"
+BR2_GCC_VERSION_10_X=y
+# BR2_GCC_VERSION_11_X is not set
+BR2_GCC_VERSION="10.3.0"
 BR2_EXTRA_GCC_CONFIG_OPTIONS=""
 # BR2_TOOLCHAIN_BUILDROOT_CXX is not set
 # BR2_TOOLCHAIN_BUILDROOT_FORTRAN is not set
@@ -327,7 +332,18 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_1=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_2=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_3=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_4=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST="5.4"
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_5=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_6=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_7=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_8=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_9=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_10=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_11=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_12=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_13=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_14=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_15=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST="5.15"
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_5=y
@@ -339,7 +355,9 @@ BR2_TOOLCHAIN_GCC_AT_LEAST_5=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_6=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_7=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_8=y
-BR2_TOOLCHAIN_GCC_AT_LEAST="8"
+BR2_TOOLCHAIN_GCC_AT_LEAST_9=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_10=y
+BR2_TOOLCHAIN_GCC_AT_LEAST="10"
 BR2_TOOLCHAIN_HAS_MNAN_OPTION=y
 BR2_TOOLCHAIN_HAS_SYNC_1=y
 BR2_TOOLCHAIN_HAS_SYNC_2=y
@@ -407,6 +425,7 @@ BR2_ENABLE_LOCALE_WHITELIST="C en_US"
 # BR2_TARGET_TZ_INFO is not set
 BR2_ROOTFS_USERS_TABLES=""
 BR2_ROOTFS_OVERLAY=""
+BR2_ROOTFS_PRE_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_FAKEROOT_SCRIPT=""
 BR2_ROOTFS_POST_IMAGE_SCRIPT=""
@@ -423,7 +442,7 @@ BR2_LINUX_KERNEL_LATEST_VERSION=y
 # BR2_LINUX_KERNEL_CUSTOM_GIT is not set
 # BR2_LINUX_KERNEL_CUSTOM_HG is not set
 # BR2_LINUX_KERNEL_CUSTOM_SVN is not set
-BR2_LINUX_KERNEL_VERSION="5.9.16"
+BR2_LINUX_KERNEL_VERSION="5.15.39"
 BR2_LINUX_KERNEL_PATCH="$(BAO_DEMOS_LINUX_PATCHES)"
 # BR2_LINUX_KERNEL_USE_DEFCONFIG is not set
 BR2_LINUX_KERNEL_USE_ARCH_DEFAULT_CONFIG=y
@@ -431,6 +450,7 @@ BR2_LINUX_KERNEL_USE_ARCH_DEFAULT_CONFIG=y
 BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="$(BAO_DEMOS_LINUX_CFG_FRAG)"
 BR2_LINUX_KERNEL_CUSTOM_LOGO_PATH=""
 BR2_LINUX_KERNEL_IMAGE=y
+# BR2_LINUX_KERNEL_IMAGEGZ is not set
 # BR2_LINUX_KERNEL_VMLINUX is not set
 # BR2_LINUX_KERNEL_IMAGE_TARGET_CUSTOM is not set
 BR2_LINUX_KERNEL_GZIP=y
@@ -442,11 +462,11 @@ BR2_LINUX_KERNEL_GZIP=y
 # BR2_LINUX_KERNEL_DTS_SUPPORT is not set
 # BR2_LINUX_KERNEL_NEEDS_HOST_OPENSSL is not set
 # BR2_LINUX_KERNEL_NEEDS_HOST_LIBELF is not set
+# BR2_LINUX_KERNEL_NEEDS_HOST_PAHOLE is not set
 
 #
 # Linux Kernel Extensions
 #
-# BR2_LINUX_KERNEL_EXT_RTAI is not set
 # BR2_LINUX_KERNEL_EXT_EV3DEV_LINUX_DRIVERS is not set
 # BR2_LINUX_KERNEL_EXT_FBTFT is not set
 # BR2_LINUX_KERNEL_EXT_AUFS is not set
@@ -461,7 +481,7 @@ BR2_LINUX_KERNEL_GZIP=y
 # BR2_PACKAGE_LINUX_TOOLS_PERF is not set
 
 #
-# selftests needs BR2_PACKAGE_BUSYBOX_SHOW_OTHERS and a toolchain w/ dynamic library
+# selftests needs BR2_PACKAGE_BUSYBOX_SHOW_OTHERS and a toolchain w/ dynamic library and headers >= 3.14
 #
 # BR2_PACKAGE_LINUX_TOOLS_TMON is not set
 
@@ -488,7 +508,7 @@ BR2_PACKAGE_SKELETON_INIT_SYSV=y
 # BR2_PACKAGE_AUMIX is not set
 
 #
-# bluez-alsa needs a toolchain w/ wchar, NPTL, headers >= 3.4, dynamic library
+# bluez-alsa needs a toolchain w/ wchar, NPTL, headers >= 3.4, dynamic library, gcc >= 4.9
 #
 # BR2_PACKAGE_DVBLAST is not set
 # BR2_PACKAGE_DVDAUTHOR is not set
@@ -514,7 +534,7 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLUID_SOUNDFONT is not set
 
 #
-# fluidsynth needs a toolchain w/ threads, wchar, dynamic library
+# fluidsynth needs a toolchain w/ threads, wchar, dynamic library, C++
 #
 
 #
@@ -532,11 +552,11 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 
 #
-# kodi needs python w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.8
+# kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.9
 #
 
 #
-# kodi needs an OpenGL EGL backend with OpenGL support
+# kodi needs an OpenGL EGL backend with OpenGL or GLES support
 #
 # BR2_PACKAGE_LAME is not set
 # BR2_PACKAGE_MADPLAY is not set
@@ -560,11 +580,14 @@ BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MOTION is not set
 
 #
-# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 6
+# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 8, host gcc >= 8
 #
 # BR2_PACKAGE_MPD_MPC is not set
 # BR2_PACKAGE_MPG123 is not set
-# BR2_PACKAGE_MPV is not set
+
+#
+# mpv needs a toolchain w/ C++, threads, gcc >= 4.9
+#
 # BR2_PACKAGE_MULTICAT is not set
 # BR2_PACKAGE_MUSEPACK is not set
 
@@ -584,7 +607,7 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 #
 
 #
-# tovid needs a toolchain w/ threads, C++, wchar, gcc >= 4.5
+# tovid needs a toolchain w/ threads, C++, wchar, gcc >= 4.9
 #
 # BR2_PACKAGE_TSTOOLS is not set
 # BR2_PACKAGE_TWOLAME is not set
@@ -606,6 +629,10 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 # BR2_PACKAGE_WAVPACK is not set
 # BR2_PACKAGE_YAVTA is not set
 # BR2_PACKAGE_YMPD is not set
+
+#
+# zynaddsubfx needs a toolchain w/ C++11 and threads
+#
 
 #
 # Compressors and decompressors
@@ -650,15 +677,24 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 #
 # bonnie++ needs a toolchain w/ C++
 #
+BR2_PACKAGE_BPFTOOL_ARCH_SUPPORTS=y
+
+#
+# bpftool needs a uClibc or glibc toolchain w/ wchar, dynamic library, threads, headers >= 4.12
+#
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 
 #
 # clinfo needs an OpenCL provider
 #
+# BR2_PACKAGE_COREMARK is not set
+# BR2_PACKAGE_COREMARK_PRO is not set
 
 #
 # dacapo needs OpenJDK
 #
+BR2_PACKAGE_DELVE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_DELVE is not set
 # BR2_PACKAGE_DHRYSTONE is not set
 # BR2_PACKAGE_DIEHARDER is not set
 # BR2_PACKAGE_DMALLOC is not set
@@ -698,6 +734,11 @@ BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 #
 # latencytop needs a toolchain w/ wchar, threads
 #
+BR2_PACKAGE_LIBBPF_ARCH_SUPPORTS=y
+
+#
+# libbpf needs a uClibc or glibc toolchain w/ wchar, dynamic library, threads, headers >= 4.13
+#
 # BR2_PACKAGE_LMBENCH is not set
 BR2_PACKAGE_LTP_TESTSUITE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LTP_TESTSUITE is not set
@@ -732,12 +773,22 @@ BR2_PACKAGE_OPROFILE_ARCH_SUPPORTS=y
 #
 # piglit needs glibc or musl
 #
+BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
+# BR2_PACKAGE_PLY is not set
+
+#
+# poke needs a toolchain w/ NPTL, wchar
+#
 BR2_PACKAGE_PTM2HUMAN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PTM2HUMAN is not set
 # BR2_PACKAGE_PV is not set
 # BR2_PACKAGE_RAMSMP is not set
 # BR2_PACKAGE_RAMSPEED is not set
 # BR2_PACKAGE_RT_TESTS is not set
+
+#
+# rwmem needs a toolchain w/ C++, wchar, gcc >= 5
+#
 
 #
 # sentry-native needs a glibc toolchain with w/ wchar, thread, C++, gcc >= 4.8
@@ -758,6 +809,8 @@ BR2_PACKAGE_TCF_AGENT_ARCH_SUPPORTS=y
 BR2_PACKAGE_TRINITY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TRINITY is not set
 # BR2_PACKAGE_UCLIBC_NG_TEST is not set
+BR2_PACKAGE_UFTRACE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_UFTRACE is not set
 BR2_PACKAGE_VALGRIND_ARCH_SUPPORTS=y
 # BR2_PACKAGE_VALGRIND is not set
 # BR2_PACKAGE_VMTOUCH is not set
@@ -808,6 +861,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_JQ is not set
 # BR2_PACKAGE_LIBTOOL is not set
 # BR2_PACKAGE_MAKE is not set
+# BR2_PACKAGE_MAWK is not set
 # BR2_PACKAGE_PKGCONF is not set
 # BR2_PACKAGE_SUBVERSION is not set
 
@@ -863,6 +917,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 # f2fs-tools needs a toolchain w/ wchar
 #
+# BR2_PACKAGE_FIRMWARE_UTILS is not set
 # BR2_PACKAGE_FLASHBENCH is not set
 # BR2_PACKAGE_FSCRYPTCTL is not set
 # BR2_PACKAGE_FUSE_OVERLAYFS is not set
@@ -873,6 +928,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_GENEXT2FS is not set
 # BR2_PACKAGE_GENPART is not set
 # BR2_PACKAGE_GENROMFS is not set
+# BR2_PACKAGE_GOCRYPTFS is not set
 # BR2_PACKAGE_IMX_USB_LOADER is not set
 # BR2_PACKAGE_MMC_UTILS is not set
 # BR2_PACKAGE_MTD is not set
@@ -900,6 +956,10 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_XFSPROGS is not set
 
 #
+# zfs needs udev /dev management
+#
+
+#
 # Fonts, cursors, icons, sounds and themes
 #
 
@@ -919,6 +979,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_GHOSTSCRIPT_FONTS is not set
 # BR2_PACKAGE_INCONSOLATA is not set
 # BR2_PACKAGE_LIBERATION is not set
+# BR2_PACKAGE_WQY_ZENHEI is not set
 
 #
 # Icons
@@ -945,6 +1006,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 # flare-engine needs a toolchain w/ C++, dynamic library
 #
+# BR2_PACKAGE_FROTZ is not set
 
 #
 # gnuchess needs a toolchain w/ C++, threads
@@ -964,8 +1026,9 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
-# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 6
+# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 7
 #
+# BR2_PACKAGE_XORCURSES is not set
 
 #
 # Graphic libraries and applications (graphic/text)
@@ -976,7 +1039,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
-# cage needs udev, mesa3d w/ EGL and GLES support
+# cage needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -999,7 +1062,20 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
+# kmscube needs EGL, GBM and OpenGL ES, and a toolchain w/ thread support
+#
+
+#
 # libva-utils needs a toolchain w/ C++, threads, dynamic library
+#
+BR2_PACKAGE_MIDORI_ARCH_SUPPORTS=y
+
+#
+# midori needs a glibc toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 8
+#
+
+#
+# midori needs libgtk3 w/ X11 or wayland backend
 #
 BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NETSURF is not set
@@ -1014,15 +1090,16 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 
 #
-# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 4.8, dynamic library, wchar
+# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 7, dynamic library, wchar
 #
+# BR2_PACKAGE_TINIFIER is not set
 
 #
 # Graphic libraries
 #
 
 #
-# cegui needs a toolchain w/ C++, threads, dynamic library, wchar
+# cegui needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 5
 #
 
 #
@@ -1046,6 +1123,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_GRAPHICSMAGICK is not set
 # BR2_PACKAGE_IMAGEMAGICK is not set
+# BR2_PACKAGE_LIBGLVND is not set
 # BR2_PACKAGE_LINUX_FUSION is not set
 
 #
@@ -1065,6 +1143,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_SDL is not set
 # BR2_PACKAGE_SDL2 is not set
+# BR2_PACKAGE_VULKAN_HEADERS is not set
 
 #
 # Other GUIs
@@ -1088,11 +1167,11 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.9
+# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 7
 #
 
 #
-# midori needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# mupdf needs a toolchain w/ C++, gcc >= 4.9
 #
 
 #
@@ -1100,7 +1179,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# vte needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# vte needs a uClibc or glibc toolchain w/ wchar, threads, C++, gcc >= 10
 #
 
 #
@@ -1117,12 +1196,13 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # BR2_PACKAGE_ARMBIAN_FIRMWARE is not set
 # BR2_PACKAGE_B43_FIRMWARE is not set
+# BR2_PACKAGE_BRCMFMAC_SDIO_FIRMWARE_RPI is not set
 # BR2_PACKAGE_LINUX_FIRMWARE is not set
 # BR2_PACKAGE_MURATA_CYW_FW is not set
 # BR2_PACKAGE_ODROIDC2_FIRMWARE is not set
-# BR2_PACKAGE_RPI_BT_FIRMWARE is not set
+# BR2_PACKAGE_QCOM_DB410C_FIRMWARE is not set
+# BR2_PACKAGE_RCW_SMARC_SAL28 is not set
 # BR2_PACKAGE_RPI_FIRMWARE is not set
-# BR2_PACKAGE_RPI_WIFI_FIRMWARE is not set
 # BR2_PACKAGE_UX500_FIRMWARE is not set
 # BR2_PACKAGE_WILC1000_FIRMWARE is not set
 # BR2_PACKAGE_WILINK_BT_FIRMWARE is not set
@@ -1142,7 +1222,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# avrdude needs a uClibc or glibc toolchain w/ threads, wchar, dynamic library
+# avrdude needs a uClibc or glibc toolchain w/ threads, wchar, dynamic library, gcc >= 4.9
 #
 
 #
@@ -1158,7 +1238,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# cc-tool needs a toolchain w/ C++, threads, wchar
+# cc-tool needs a toolchain w/ C++, threads, wchar, gcc >= 4.9 
 #
 # BR2_PACKAGE_CDRKIT is not set
 BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
@@ -1167,6 +1247,10 @@ BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_DAHDI_LINUX is not set
 # BR2_PACKAGE_DAHDI_TOOLS is not set
 # BR2_PACKAGE_DBUS is not set
+
+#
+# dbus-cxx needs a toolchain w/ C++, threads, gcc >= 7 and dynamic library support
+#
 # BR2_PACKAGE_DFU_UTIL is not set
 # BR2_PACKAGE_DMIDECODE is not set
 # BR2_PACKAGE_DMRAID is not set
@@ -1174,6 +1258,7 @@ BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
 #
 # dt-utils needs udev /dev management
 #
+# BR2_PACKAGE_DTBOCFG is not set
 # BR2_PACKAGE_DTV_SCAN_TABLES is not set
 # BR2_PACKAGE_DUMP1090 is not set
 # BR2_PACKAGE_DVB_APPS is not set
@@ -1193,6 +1278,7 @@ BR2_PACKAGE_CPUBURN_ARM_ARCH_SUPPORTS=y
 BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLASHROM is not set
 # BR2_PACKAGE_FMTOOLS is not set
+# BR2_PACKAGE_FREEIPMI is not set
 # BR2_PACKAGE_FREESCALE_IMX is not set
 # BR2_PACKAGE_FXLOAD is not set
 # BR2_PACKAGE_GPM is not set
@@ -1208,11 +1294,14 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HWDATA is not set
 # BR2_PACKAGE_HWLOC is not set
 # BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
-# BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_IPMITOOL is not set
 # BR2_PACKAGE_IRDA_UTILS is not set
 # BR2_PACKAGE_KBD is not set
 # BR2_PACKAGE_LCDPROC is not set
+
+#
+# libiec61850 needs a toolchain w/ C++, threads, dynamic library
+#
 # BR2_PACKAGE_LIBUBOOTENV is not set
 # BR2_PACKAGE_LIBUIO is not set
 # BR2_PACKAGE_LINUX_BACKPORTS is not set
@@ -1231,6 +1320,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LSUIO is not set
 # BR2_PACKAGE_LUKSMETA is not set
 # BR2_PACKAGE_LVM2 is not set
+# BR2_PACKAGE_MALI_DRIVER is not set
 # BR2_PACKAGE_MBPFAN is not set
 # BR2_PACKAGE_MDADM is not set
 # BR2_PACKAGE_MDEVD is not set
@@ -1245,6 +1335,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 #
 # neard needs a toolchain w/ wchar, threads, dynamic library
 #
+# BR2_PACKAGE_NVIDIA_MODPROBE is not set
 # BR2_PACKAGE_NVME is not set
 
 #
@@ -1253,7 +1344,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPEN2300 is not set
 
 #
-# openfpgaloader needs a toolchain w/ threads, C++
+# openfpgaloader needs a toolchain w/ threads, C++, gcc >= 4.9
 #
 # BR2_PACKAGE_OPENIPMI is not set
 # BR2_PACKAGE_OPENOCD is not set
@@ -1270,15 +1361,18 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # powertop needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_PPS_TOOLS is not set
+# BR2_PACKAGE_QORIQ_CADENCE_DP_FIRMWARE is not set
 # BR2_PACKAGE_RASPI_GPIO is not set
 # BR2_PACKAGE_READ_EDID is not set
 # BR2_PACKAGE_RNG_TOOLS is not set
 # BR2_PACKAGE_RS485CONF is not set
 # BR2_PACKAGE_RTC_TOOLS is not set
 # BR2_PACKAGE_RTL8188EU is not set
+# BR2_PACKAGE_RTL8189ES is not set
 # BR2_PACKAGE_RTL8189FS is not set
 # BR2_PACKAGE_RTL8723BS is not set
 # BR2_PACKAGE_RTL8723BU is not set
+# BR2_PACKAGE_RTL8812AU_AIRCRACK_NG is not set
 # BR2_PACKAGE_RTL8821AU is not set
 # BR2_PACKAGE_SANE_BACKENDS is not set
 # BR2_PACKAGE_SDPARM is not set
@@ -1295,7 +1389,7 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 
 #
-# sispmctl needs a toolchain w/ threads, wchar
+# sispmctl needs a toolchain w/ threads, wchar, gcc >= 4.9
 #
 
 #
@@ -1314,18 +1408,6 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 # targetcli-fb depends on Python
 #
-
-#
-# ti-sgx-libgbm needs udev and a toolchain w/ threads
-#
-
-#
-# ti-sgx-um needs the ti-sgx-km driver
-#
-
-#
-# ti-sgx-um needs udev and a glibc toolchain w/ threads
-#
 # BR2_PACKAGE_TI_UIM is not set
 # BR2_PACKAGE_TI_UTILS is not set
 # BR2_PACKAGE_TIO is not set
@@ -1339,7 +1421,7 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 
 #
-# udisks needs a glibc or musl toolchain with locale, C++, wchar, dynamic library, NPTL, gcc >= 4.9
+# udisks needs a toolchain with dynamic library, locale, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_UHUBCTL is not set
 # BR2_PACKAGE_UMTPRD is not set
@@ -1349,17 +1431,21 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 
 #
-# upower needs a toolchain w/ threads, wchar
+# upower needs a toolchain w/ threads, wchar, gcc >= 4.9
 #
 # BR2_PACKAGE_USB_MODESWITCH is not set
 # BR2_PACKAGE_USB_MODESWITCH_DATA is not set
+
+#
+# usbguard needs a glibc or uClibc toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+#
 
 #
 # usbmount requires udev to be enabled
 #
 
 #
-# usbutils needs udev /dev management and toolchain w/ threads
+# usbutils needs udev /dev management and toolchain w/ threads, gcc >= 4.9
 #
 # BR2_PACKAGE_W_SCAN is not set
 # BR2_PACKAGE_WIPE is not set
@@ -1384,6 +1470,7 @@ BR2_PACKAGE_ERLANG_ARCH_SUPPORTS=y
 # guile needs a uClibc or glibc toolchain w/ threads, wchar, dynamic library
 #
 # BR2_PACKAGE_HASERL is not set
+# BR2_PACKAGE_JANET is not set
 # BR2_PACKAGE_JIMTCL is not set
 # BR2_PACKAGE_LUA is not set
 BR2_PACKAGE_PROVIDES_HOST_LUAINTERPRETER="host-lua"
@@ -1395,7 +1482,7 @@ BR2_PACKAGE_HOST_MONO_ARCH_SUPPORTS=y
 BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
 
 #
-# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 4.9, wchar
+# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 7, wchar, host gcc >= 8
 #
 BR2_PACKAGE_HOST_OPENJDK_BIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
@@ -1405,13 +1492,12 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 #
 
 #
-# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++
+# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++, gcc >= 4.9, host gcc >= 4.9
 #
 # BR2_PACKAGE_PERL is not set
-# BR2_PACKAGE_PHP is not set
 
 #
-# python needs a toolchain w/ wchar, threads, dynamic library
+# php needs a toolchain w/ wchar
 #
 
 #
@@ -1419,7 +1505,11 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 #
 
 #
-# ruby needs a toolchain w/ wchar, threads, dynamic library
+# quickjs needs a glibc or musl toolchain w/ gcc >= 4.9, host gcc >= 4.9, dynamic library
+#
+
+#
+# ruby needs a toolchain w/ wchar, threads, dynamic library, gcc >= 4.9, host gcc >= 4.9
 #
 # BR2_PACKAGE_TCL is not set
 
@@ -1436,10 +1526,6 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 # alure needs a toolchain w/ C++, gcc >= 4.9, NPTL, wchar
 #
 # BR2_PACKAGE_AUBIO is not set
-
-#
-# audiofile needs a toolchain w/ C++
-#
 # BR2_PACKAGE_BCG729 is not set
 
 #
@@ -1493,9 +1579,11 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBSOXR is not set
 # BR2_PACKAGE_LIBVORBIS is not set
+# BR2_PACKAGE_LILV is not set
+# BR2_PACKAGE_LV2 is not set
 
 #
-# mp4v2 needs a toolchain w/ C++
+# mp4v2 needs a toolchain w/ C++, gcc >= 5
 #
 BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 
@@ -1513,6 +1601,7 @@ BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SPANDSP is not set
 # BR2_PACKAGE_SPEEX is not set
 # BR2_PACKAGE_SPEEXDSP is not set
+# BR2_PACKAGE_SRATOM is not set
 
 #
 # taglib needs a toolchain w/ C++, wchar
@@ -1550,6 +1639,7 @@ BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
 # snappy needs a toolchain w/ C++
 #
 # BR2_PACKAGE_SZIP is not set
+# BR2_PACKAGE_ZCHUNK is not set
 BR2_PACKAGE_ZLIB_NG_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ZLIB is not set
 BR2_PACKAGE_PROVIDES_HOST_ZLIB="host-libzlib"
@@ -1569,6 +1659,10 @@ BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_CRYPTODEV is not set
 
 #
+# cryptopp needs a toolchain w/ C++, dynamic library, wchar
+#
+
+#
 # gcr needs a toolchain w/ wchar, threads, dynamic library
 #
 
@@ -1584,7 +1678,7 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="aarch64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBGPGME is not set
 # BR2_PACKAGE_LIBKCAPI is not set
 # BR2_PACKAGE_LIBKSBA is not set
-# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_LIBMD is not set
 # BR2_PACKAGE_LIBMHASH is not set
 # BR2_PACKAGE_LIBNSS is not set
 
@@ -1603,6 +1697,7 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="aarch64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBSSH2 is not set
 # BR2_PACKAGE_LIBTOMCRYPT is not set
 # BR2_PACKAGE_LIBUECC is not set
+# BR2_PACKAGE_LIBXCRYPT is not set
 # BR2_PACKAGE_MBEDTLS is not set
 # BR2_PACKAGE_NETTLE is not set
 # BR2_PACKAGE_OPENSSL is not set
@@ -1610,6 +1705,7 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 # BR2_PACKAGE_PKCS11_HELPER is not set
 # BR2_PACKAGE_RHASH is not set
 # BR2_PACKAGE_TINYDTLS is not set
+# BR2_PACKAGE_TPM2_PKCS11 is not set
 # BR2_PACKAGE_TPM2_TSS is not set
 # BR2_PACKAGE_TROUSERS is not set
 # BR2_PACKAGE_USTREAM_SSL is not set
@@ -1619,7 +1715,10 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 # Database
 #
 # BR2_PACKAGE_BERKELEYDB is not set
-# BR2_PACKAGE_GDBM is not set
+
+#
+# gdbm needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_HIREDIS is not set
 
 #
@@ -1629,7 +1728,10 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 #
 # leveldb needs a toolchain w/ C++, threads, gcc >= 4.8
 #
+# BR2_PACKAGE_LIBDBI is not set
+# BR2_PACKAGE_LIBDBI_DRIVERS is not set
 # BR2_PACKAGE_LIBGIT2 is not set
+# BR2_PACKAGE_LIBMDBX is not set
 
 #
 # libodb needs a toolchain w/ C++, threads
@@ -1648,6 +1750,7 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 # postgresql needs a toolchain w/ dynamic library, wchar
 #
 # BR2_PACKAGE_REDIS is not set
+BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 
 #
 # rocksdb needs a toolchain w/ C++, threads, wchar, gcc >= 4.8
@@ -1705,16 +1808,21 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 
 #
-# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
+#
+BR2_PACKAGE_BAYER2RGB_NEON_ARCH_SUPPORTS=y
+
+#
+# bayer2rgb-neon needs a toolchain w/ C++, dynamic library, gcc >= 4.9
 #
 
 #
-# bullet needs a toolchain w/ C++
+# bullet needs a toolchain w/ C++, dynamic library, threads, wchar
 #
 # BR2_PACKAGE_CAIRO is not set
 
 #
-# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.8
+# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -1738,7 +1846,7 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GIFLIB is not set
 
 #
-# granite needs libgtk3 and a toolchain w/ wchar, threads
+# granite needs libgtk3 and a toolchain w/ wchar, threads, gcc >= 4.9
 #
 
 #
@@ -1746,14 +1854,18 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 
 #
-# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# harfbuzz needs a toolchain w/ C++, gcc >= 4.8
+# harfbuzz needs a toolchain w/ C++, gcc >= 4.9
 #
 # BR2_PACKAGE_IJS is not set
 # BR2_PACKAGE_IMLIB2 is not set
+
+#
+# intel-gmmlib needs a toolchain w/ dynamic library, C++
+#
 
 #
 # irrlicht needs a toolchain w/ C++
@@ -1764,7 +1876,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_JPEG is not set
 
 #
-# kms++ needs a toolchain w/ threads, C++, gcc >= 4.8, headers >= 3.8
+# kms++ needs a toolchain w/ threads, C++, gcc >= 4.8, headers >= 4.11, wchar
 #
 # BR2_PACKAGE_LCMS2 is not set
 
@@ -1782,7 +1894,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBEXIF is not set
 
 #
-# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
@@ -1806,7 +1918,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# libglfw depends on X.org and needs an OpenGL backend
+# libglfw depends on X.org or Wayland and an OpenGL or GLES backend
 #
 
 #
@@ -1815,7 +1927,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBGTA is not set
 
 #
-# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
@@ -1831,10 +1943,6 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 
 #
 # libraw needs a toolchain w/ C++
-#
-
-#
-# libsoil needs an OpenGL backend and a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBSVG is not set
 # BR2_PACKAGE_LIBSVG_CAIRO is not set
@@ -1856,35 +1964,36 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 # opencv3 needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
+
+#
+# opencv4 needs a toolchain w/ C++, NPTL, wchar, dynamic library, gcc >= 4.8
+#
 # BR2_PACKAGE_OPENJPEG is not set
 
 #
-# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
-# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
-
-#
-# pipewire needs udev and a toolchain w/ threads
-#
+# BR2_PACKAGE_PIPEWIRE is not set
 # BR2_PACKAGE_PIXMAN is not set
 
 #
-# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 5
+# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_TIFF is not set
 # BR2_PACKAGE_WAYLAND is not set
 BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
 
 #
-# webkitgtk needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# webkitgtk needs libgtk3 and a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 4.9
 #
 # BR2_PACKAGE_WEBP is not set
 
 #
-# wlroots needs udev, mesa3d w/ EGL and GLES support
+# wlroots needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -1924,7 +2033,7 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HACKRF is not set
 
 #
-# hidapi needs udev /dev management and a toolchain w/ NPTL threads
+# hidapi needs udev /dev management and a toolchain w/ NPTL, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_JITTERENTROPY_LIBRARY is not set
 
@@ -1977,6 +2086,10 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 #
 # libqmi needs a toolchain w/ wchar, threads
 #
+
+#
+# libqrtr-glib needs a toolchain w/ wchar, threads, headers >= 4.15
+#
 # BR2_PACKAGE_LIBRAW1394 is not set
 # BR2_PACKAGE_LIBRTLSDR is not set
 
@@ -2012,6 +2125,10 @@ BR2_PACKAGE_NE10_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_OWFS is not set
 # BR2_PACKAGE_PCSC_LITE is not set
+
+#
+# rpi-rgb-led-matrix needs a toolchain w/ C++, threads, dynamic library
+#
 # BR2_PACKAGE_TSLIB is not set
 
 #
@@ -2028,19 +2145,16 @@ BR2_PACKAGE_NE10_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ANGULARJS is not set
 # BR2_PACKAGE_BOOTSTRAP is not set
 # BR2_PACKAGE_CHARTJS is not set
+# BR2_PACKAGE_DATATABLES is not set
 # BR2_PACKAGE_DUKTAPE is not set
 # BR2_PACKAGE_EXPLORERCANVAS is not set
 # BR2_PACKAGE_FLOT is not set
 # BR2_PACKAGE_JQUERY is not set
 # BR2_PACKAGE_JSMIN is not set
 # BR2_PACKAGE_JSON_JAVASCRIPT is not set
+# BR2_PACKAGE_JSZIP is not set
 # BR2_PACKAGE_OPENLAYERS is not set
-BR2_PACKAGE_SPIDERMONKEY_ARCH_SUPPORTS=y
-BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
-
-#
-# spidermonkey needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
-#
+# BR2_PACKAGE_POPPERJS is not set
 # BR2_PACKAGE_VUEJS is not set
 
 #
@@ -2079,7 +2193,7 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBXML2 is not set
 
 #
-# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_LIBXMLRPC is not set
 # BR2_PACKAGE_LIBXSLT is not set
@@ -2095,6 +2209,8 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_RAPIDXML is not set
 # BR2_PACKAGE_RAPTOR is not set
+# BR2_PACKAGE_SERD is not set
+# BR2_PACKAGE_SORD is not set
 
 #
 # tinyxml needs a toolchain w/ C++
@@ -2105,11 +2221,15 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
-# valijson needs a toolchain w/ C++, threads, wchar  support
+# valijson needs a toolchain w/ C++
 #
 
 #
-# xerces-c++ needs a toolchain w/ C++, wchar
+# xerces-c++ needs a toolchain w/ C++, dynamic library, wchar
+#
+
+#
+# xml-security-c needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.7
 #
 # BR2_PACKAGE_YAJL is not set
 
@@ -2140,16 +2260,28 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
+# log4qt needs qt5
+#
+
+#
 # opentracing-cpp needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
 
 #
 # spdlog needs a toolchain w/ C++, threads, wchar
 #
+
+#
+# ulog needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_ZLOG is not set
 
 #
 # Multimedia
+#
+
+#
+# bento4 support needs a toolchain with C++
 #
 # BR2_PACKAGE_BITSTREAM is not set
 # BR2_PACKAGE_DAV1D is not set
@@ -2160,7 +2292,7 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBAACS is not set
 
 #
-# libass needs a toolchain w/ C++, gcc >= 4.8
+# libass needs a toolchain w/ C++, gcc >= 4.9
 #
 # BR2_PACKAGE_LIBBDPLUS is not set
 # BR2_PACKAGE_LIBBLURAY is not set
@@ -2168,6 +2300,10 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 
 #
 # libcamera needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
+#
+
+#
+# libcamera-apps needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_LIBDCADEC is not set
 # BR2_PACKAGE_LIBDVBCSA is not set
@@ -2194,6 +2330,7 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBMPEG2 is not set
 # BR2_PACKAGE_LIBOGG is not set
+# BR2_PACKAGE_LIBOPENAPTX is not set
 BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 
 #
@@ -2213,7 +2350,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# mediastreamer needs a toolchain w/ threads, C++, dynamic library
+# mediastreamer needs a toolchain w/ threads, C++, dynamic library, gcc >= 5
 #
 # BR2_PACKAGE_X264 is not set
 
@@ -2230,7 +2367,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# azmq needs a toolchain w/ C++11, wchar and NPTL
+# azmq needs a toolchain w/ C++11, wchar and threads
 #
 
 #
@@ -2256,6 +2393,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # czmq needs a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_DAQ is not set
+# BR2_PACKAGE_DAQ3 is not set
 # BR2_PACKAGE_DAVICI is not set
 # BR2_PACKAGE_ENET is not set
 
@@ -2307,6 +2445,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCURL is not set
 # BR2_PACKAGE_LIBDNET is not set
 # BR2_PACKAGE_LIBEXOSIP2 is not set
+# BR2_PACKAGE_LIBEST is not set
 # BR2_PACKAGE_LIBFCGI is not set
 
 #
@@ -2335,7 +2474,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBMODBUS is not set
 
 #
-# libmodsecurity needs a toolchain w/ C++, dynamic library, threads
+# libmodsecurity needs a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_LIBNATPMP is not set
 # BR2_PACKAGE_LIBNDP is not set
@@ -2368,6 +2507,10 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # libpjsip needs a toolchain w/ C++, threads
 #
+
+#
+# libpsl needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_LIBRELP is not set
 # BR2_PACKAGE_LIBRSYNC is not set
 # BR2_PACKAGE_LIBSHAIRPLAY is not set
@@ -2379,6 +2522,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBSRTP is not set
 # BR2_PACKAGE_LIBSTROPHE is not set
+# BR2_PACKAGE_LIBTEAM is not set
 # BR2_PACKAGE_LIBTELNET is not set
 # BR2_PACKAGE_LIBTIRPC is not set
 
@@ -2391,6 +2535,10 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBUEV is not set
 # BR2_PACKAGE_LIBUHTTPD is not set
+
+#
+# libuhttpd needs a toolchain w/ gcc >= 4.9
+#
 # BR2_PACKAGE_LIBUPNP is not set
 
 #
@@ -2428,6 +2576,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # omniORB needs a toolchain w/ C++, threads
 #
+# BR2_PACKAGE_OPEN62541 is not set
 
 #
 # openldap needs a toolchain w/ wchar
@@ -2455,7 +2604,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar
+# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar, not binutils bug 27597
 #
 # BR2_PACKAGE_QDECODER is not set
 # BR2_PACKAGE_QPID_PROTON is not set
@@ -2469,6 +2618,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # restclient-cpp needs a toolchain w/ C++, gcc >= 4.8
 #
 # BR2_PACKAGE_RTMPDUMP is not set
+# BR2_PACKAGE_SIPROXD is not set
 
 #
 # slirp needs a toolchain w/ wchar, threads
@@ -2510,6 +2660,10 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 
 #
 # Other
+#
+
+#
+# ACE needs a glibc toolchain, dynamic library, C++, gcc >= 4.8
 #
 # BR2_PACKAGE_APR is not set
 # BR2_PACKAGE_APR_UTIL is not set
@@ -2556,7 +2710,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # clang needs a toolchain w/ wchar, threads, C++, gcc >= 4.8, dynamic library
 #
-# BR2_PACKAGE_CLAPACK is not set
 # BR2_PACKAGE_CMOCKA is not set
 
 #
@@ -2578,7 +2731,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# ell needs a toolchain w/ dynamic library, wchar, headers >= 4.12
+# ell needs a toolchain w/ wchar, headers >= 4.12
 #
 # BR2_PACKAGE_FFTW is not set
 
@@ -2604,7 +2757,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -2618,15 +2771,17 @@ BR2_PACKAGE_GOBJECT_INTROSPECTION_ARCH_SUPPORTS=y
 #
 
 #
-# gobject-introspection needs a glibc toolchain, gcc >= 4.9
+# gobject-introspection needs a glibc toolchain, gcc >= 4.9, host gcc >= 8
 #
 # BR2_PACKAGE_GSL is not set
 
 #
-# gtest needs a toolchain w/ C++, wchar, threads
+# gtest needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
 #
+# BR2_PACKAGE_GUMBO_PARSER is not set
 BR2_PACKAGE_JEMALLOC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JEMALLOC is not set
+BR2_PACKAGE_LAPACK_ARCH_SUPPORTS=y
 
 #
 # lapack/blas needs a toolchain w/ fortran
@@ -2666,10 +2821,19 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBEV is not set
 # BR2_PACKAGE_LIBEVDEV is not set
 # BR2_PACKAGE_LIBEVENT is not set
+# BR2_PACKAGE_LIBEXECINFO is not set
 # BR2_PACKAGE_LIBFFI is not set
 
 #
-# libgee needs a toolchain w/ wchar, threads
+# libfutils needs a toolchain w/ C++, threads
+#
+
+#
+# libgee needs a toolchain w/ wchar, threads, gcc >= 4.9
+#
+
+#
+# libgeos needs a toolchain w/ C++, wchar, threads not binutils bug 27597
 #
 
 #
@@ -2683,6 +2847,10 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBITE is not set
 
 #
+# libks needs a toolchain w/ C++, NPTL, dynamic library
+#
+
+#
 # liblinear needs a toolchain w/ C++
 #
 
@@ -2692,6 +2860,18 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBNPTH is not set
 BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBNSPR is not set
+
+#
+# libosmium needs a toolchain w/ C++,  wchar, threads, gcc >= 4.7
+#
+
+#
+# libpeas needs python3
+#
+
+#
+# libpeas needs a glibc toolchain, gcc >= 4.9, host gcc >= 8
+#
 # BR2_PACKAGE_LIBPFM4 is not set
 
 #
@@ -2700,16 +2880,22 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBPTHREAD_STUBS is not set
 # BR2_PACKAGE_LIBPTHSEM is not set
 # BR2_PACKAGE_LIBPWQUALITY is not set
+# BR2_PACKAGE_LIBQB is not set
 BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSECCOMP is not set
 
 #
-# libsigc++ needs a toolchain w/ C++, gcc >= 4.8
+# libshdata needs a toolchain w/ C++, threads
+#
+
+#
+# libsigc++ needs a toolchain w/ C++, gcc >= 7
 #
 
 #
 # libspatialindex needs a toolchain w/ C++, gcc >= 4.7
 #
+# BR2_PACKAGE_LIBTALLOC is not set
 # BR2_PACKAGE_LIBTASN1 is not set
 # BR2_PACKAGE_LIBTOMMATH is not set
 # BR2_PACKAGE_LIBTPL is not set
@@ -2717,6 +2903,7 @@ BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBUCI is not set
 BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBURCU is not set
+# BR2_PACKAGE_LIBURING is not set
 # BR2_PACKAGE_LIBUV is not set
 
 #
@@ -2767,7 +2954,11 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 
 #
-# qhull needs a toolchain w/ C++, dynamic library, gcc >= 4.4
+# protozero needs a toolchain w/ C++,  gcc >= 4.7
+#
+
+#
+# qhull needs a toolchain w/ C++, gcc >= 4.4
 #
 
 #
@@ -2803,6 +2994,10 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SAFECLIB is not set
 
 #
+# softhsm2 needs a toolchain w/ C++, threads, gcc >= 4.8 and dynamic library support
+#
+
+#
 # Text and terminal handling
 #
 
@@ -2825,6 +3020,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 # icu needs a toolchain w/ C++, wchar, threads, gcc >= 4.9, host gcc >= 4.9
 #
+# BR2_PACKAGE_INIH is not set
 # BR2_PACKAGE_LIBCLI is not set
 
 #
@@ -2892,7 +3088,7 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_COLLECTL is not set
 
 #
-# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 4.8, NPTL, wchar, dynamic library
+# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 6, NPTL, wchar, dynamic library
 #
 # BR2_PACKAGE_EMPTY is not set
 
@@ -2914,7 +3110,6 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_HAVEGED is not set
 # BR2_PACKAGE_LINUX_SYSCALL_SUPPORT is not set
-# BR2_PACKAGE_MCRYPT is not set
 # BR2_PACKAGE_MOBILE_BROADBAND_PROVIDER_INFO is not set
 # BR2_PACKAGE_NETDATA is not set
 
@@ -2924,12 +3119,13 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 
 #
-# QEMU requires a toolchain with wchar, threads
+# QEMU requires a toolchain with wchar, threads, gcc >= 8
 #
 
 #
-# qpdf needs a toolchain w/ C++, wchar, gcc >= 4.7
+# qpdf needs a toolchain w/ C++, gcc >= 5
 #
+# BR2_PACKAGE_RTL_433 is not set
 
 #
 # shared-mime-info needs a toolchain w/ wchar, threads
@@ -2942,6 +3138,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # taskd needs a toolchain w/ C++, wchar, dynamic library
 #
+
+#
+# xmrig needs a glibc or musl toolchain w/ NPTL, dynamic library, C++
+#
 # BR2_PACKAGE_XUTIL_UTIL_MACROS is not set
 
 #
@@ -2951,6 +3151,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # aircrack-ng needs a toolchain w/ dynamic library, threads, C++
 #
+# BR2_PACKAGE_ALFRED is not set
 # BR2_PACKAGE_AOETOOLS is not set
 # BR2_PACKAGE_APACHE is not set
 # BR2_PACKAGE_ARGUS is not set
@@ -2978,10 +3179,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # bluez5-utils needs a toolchain w/ wchar, threads, headers >= 3.4, dynamic library
 #
 # BR2_PACKAGE_BMON is not set
-# BR2_PACKAGE_BOA is not set
+# BR2_PACKAGE_BMX7 is not set
 
 #
-# boinc needs a toolchain w/ dynamic library, C++, threads
+# boinc needs a toolchain w/ dynamic library, C++, threads, gcc >= 4.8
 #
 # BR2_PACKAGE_BRCM_PATCHRAM_PLUS is not set
 # BR2_PACKAGE_BRIDGE_UTILS is not set
@@ -2992,6 +3193,11 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # cannelloni needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
+
+#
+# casync needs a glibc toolchain
+#
+# BR2_PACKAGE_CFM is not set
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
 
@@ -3015,7 +3221,11 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 
 #
-# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 4.8
+# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 5
+#
+
+#
+# cups-pk-helper support needs a toolchain with threads, wchar, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_DANTE is not set
 # BR2_PACKAGE_DARKHTTPD is not set
@@ -3051,7 +3261,7 @@ BR2_PACKAGE_DROPBEAR_LOCALOPTIONS_FILE=""
 # BR2_PACKAGE_FRR is not set
 
 #
-# gerbera needs a toolchain w/ C++, threads, wchar, gcc >= 8
+# gerbera needs a toolchain w/ C++, dynamic library, threads, wchar, gcc >= 8
 #
 
 #
@@ -3111,7 +3321,6 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_IPERF3 is not set
 # BR2_PACKAGE_IPROUTE2 is not set
-# BR2_PACKAGE_IPSEC_TOOLS is not set
 # BR2_PACKAGE_IPSET is not set
 # BR2_PACKAGE_IPTABLES is not set
 # BR2_PACKAGE_IPTRAF_NG is not set
@@ -3123,7 +3332,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_IW is not set
 
 #
-# iwd needs a toolchain w/ threads, dynamic library, wchar, headers >= 4.12
+# iwd needs a toolchain w/ threads, wchar, headers >= 4.12
 #
 
 #
@@ -3132,9 +3341,13 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_KEEPALIVED is not set
 
 #
-# kismet needs a toolchain w/ threads, C++
+# kismet needs a toolchain w/ threads, C++, gcc >= 5
 #
 # BR2_PACKAGE_KNOCK is not set
+
+#
+# ksmbd-tools needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LEAFNODE2 is not set
 # BR2_PACKAGE_LFT is not set
 
@@ -3149,7 +3362,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LINKS is not set
 
 #
-# linphone needs a toolchain w/ threads, C++, dynamic library, wchar
+# linphone needs a toolchain w/ threads, C++, dynamic library, wchar, gcc >= 5
 #
 # BR2_PACKAGE_LINUX_ZIGBEE is not set
 # BR2_PACKAGE_LINUXPTP is not set
@@ -3174,7 +3387,6 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 #
 # mongrel2 needs a uClibc or glibc toolchain w/ C++, threads, dynamic library
 #
-# BR2_PACKAGE_MONKEY is not set
 
 #
 # mosh needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 4.8
@@ -3182,6 +3394,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MOSQUITTO is not set
 # BR2_PACKAGE_MROUTED is not set
 # BR2_PACKAGE_MRP is not set
+# BR2_PACKAGE_MSTPD is not set
 # BR2_PACKAGE_MTR is not set
 
 #
@@ -3196,7 +3409,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NETSTAT_NAT is not set
 
 #
-# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 3.2, dynamic library, wchar, threads
+# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 4.6, dynamic library, wchar, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_NFACCT is not set
 
@@ -3226,7 +3439,10 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPENOBEX is not set
 # BR2_PACKAGE_OPENRESOLV is not set
 # BR2_PACKAGE_OPENSSH is not set
-# BR2_PACKAGE_OPENSWAN is not set
+
+#
+# openswan needs a glibc or musl toolchain w/ headers >= 3.4
+#
 # BR2_PACKAGE_OPENVPN is not set
 # BR2_PACKAGE_P910ND is not set
 # BR2_PACKAGE_PARPROUTED is not set
@@ -3291,6 +3507,10 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 #
 # snort needs a toolchain w/ wchar, threads, dynamic library
 #
+
+#
+# snort3 needs a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 4.9
+#
 # BR2_PACKAGE_SOCAT is not set
 # BR2_PACKAGE_SOCKETCAND is not set
 
@@ -3301,8 +3521,9 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
-# squid needs a toolchain w/ C++, gcc >= 4.8 not affected by bug 64735
+# squid needs a toolchain w/ C++, threads, gcc >= 4.8 not affected by bug 64735
 #
+# BR2_PACKAGE_SSDP_RESPONDER is not set
 # BR2_PACKAGE_SSHGUARD is not set
 # BR2_PACKAGE_SSHPASS is not set
 # BR2_PACKAGE_SSLH is not set
@@ -3332,6 +3553,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_UHTTPD is not set
 # BR2_PACKAGE_ULOGD is not set
 # BR2_PACKAGE_UNBOUND is not set
+# BR2_PACKAGE_UQMI is not set
 # BR2_PACKAGE_UREDIR is not set
 # BR2_PACKAGE_USHARE is not set
 
@@ -3341,7 +3563,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_VDE2 is not set
 
 #
-# vdr needs a glibc toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
+# vdr needs a toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
 #
 
 #
@@ -3354,19 +3576,22 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_VSFTPD is not set
 # BR2_PACKAGE_VTUN is not set
 # BR2_PACKAGE_WAVEMON is not set
-# BR2_PACKAGE_WIREGUARD_LINUX_COMPAT is not set
 # BR2_PACKAGE_WIREGUARD_TOOLS is not set
 # BR2_PACKAGE_WIRELESS_REGDB is not set
 # BR2_PACKAGE_WIRELESS_TOOLS is not set
 
 #
-# wireshark needs a toolchain w/ wchar, threads, dynamic library
+# wireshark needs a toolchain w/ wchar, threads, dynamic library, C++
 #
 # BR2_PACKAGE_WPA_SUPPLICANT is not set
 # BR2_PACKAGE_WPAN_TOOLS is not set
 # BR2_PACKAGE_XINETD is not set
 # BR2_PACKAGE_XL2TP is not set
 # BR2_PACKAGE_XTABLES_ADDONS is not set
+
+#
+# zabbix need glibc
+#
 
 #
 # znc needs a toolchain w/ C++, dynamic library, gcc >= 4.8, threads
@@ -3425,6 +3650,10 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 #
 
 #
+# opkg-utils needs a toolchain w/ wchar, threads, dynamic library
+#
+
+#
 # Real-Time
 #
 # BR2_PACKAGE_XENOMAI is not set
@@ -3448,7 +3677,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_REFPOLICY is not set
 
 #
-# restorecond needs a toolchain w/ wchar, threads, dynamic library
+# restorecond needs a toolchain w/ wchar, threads, dynamic library, gcc >= 5
 #
 
 #
@@ -3457,7 +3686,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SEMODULE_UTILS is not set
 
 #
-# setools needs a toolchain w/ threads, wchar, dynamic library
+# setools needs a toolchain w/ threads, wchar, dynamic library, gcc >= 5
 #
 
 #
@@ -3478,6 +3707,7 @@ BR2_PACKAGE_URANDOM_SCRIPTS=y
 #
 # Utilities
 #
+# BR2_PACKAGE_APG is not set
 # BR2_PACKAGE_AT is not set
 # BR2_PACKAGE_CCRYPT is not set
 # BR2_PACKAGE_DIALOG is not set
@@ -3518,15 +3748,26 @@ BR2_PACKAGE_URANDOM_SCRIPTS=y
 #
 # BR2_PACKAGE_ACL is not set
 # BR2_PACKAGE_ANDROID_TOOLS is not set
-# BR2_PACKAGE_ATOP is not set
+
+#
+# atop needs a toolchain w/ wchar, headers >= 3.14
+#
 # BR2_PACKAGE_ATTR is not set
 BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_AUDIT is not set
+
+#
+# balena-engine needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_BUBBLEWRAP is not set
 # BR2_PACKAGE_CGROUPFS_MOUNT is not set
 
 #
 # circus needs Python 3 and a toolchain w/ C++, threads
+#
+
+#
+# containerd needs a glibc or musl toolchain w/ threads
 #
 # BR2_PACKAGE_CPULOAD is not set
 # BR2_PACKAGE_DAEMON is not set
@@ -3538,14 +3779,6 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_DOCKER_CLI is not set
 
 #
-# docker-compose needs a toolchain w/ C++, wchar, threads, dynamic library
-#
-
-#
-# docker-containerd needs a glibc or musl toolchain w/ threads
-#
-
-#
 # docker-engine needs a glibc or musl toolchain w/ threads
 #
 # BR2_PACKAGE_DOCKER_PROXY is not set
@@ -3553,15 +3786,23 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_EFIBOOTMGR is not set
 BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 # BR2_PACKAGE_EFIVAR is not set
+
+#
+# embiggen-disk needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_EMLOG is not set
 # BR2_PACKAGE_FTOP is not set
 # BR2_PACKAGE_GETENT is not set
+
+#
+# gkrellm needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_HTOP is not set
 # BR2_PACKAGE_IBM_SW_TPM2 is not set
 BR2_PACKAGE_INITSCRIPTS=y
 
 #
-# iotop depends on python or python3
+# iotop depends on python3
 #
 # BR2_PACKAGE_IPRUTILS is not set
 
@@ -3579,6 +3820,15 @@ BR2_PACKAGE_INITSCRIPTS=y
 #
 # libostree needs a uClibc or glibc toolchain w/ threads, dynamic library, wchar
 #
+BR2_PACKAGE_LIBVIRT_ARCH_SUPPORTS=y
+
+#
+# libvirt needs udev /dev management, a toolchain w/ threads, dynamic library, wchar, kernel headers >= 3.12 (4.11 for AArch64)
+#
+
+#
+# lxc needs a glibc or musl toolchain w/ threads, headers >= 3.0, dynamic library, gcc >= 4.7
+#
 BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 
 #
@@ -3586,6 +3836,10 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_MENDER is not set
 # BR2_PACKAGE_MFOC is not set
+
+#
+# moby-buildkit needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_MONIT is not set
 
 #
@@ -3596,7 +3850,6 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # netifrc needs openrc as init system
 #
-BR2_PACKAGE_NUMACTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NUMACTL is not set
 
 #
@@ -3608,7 +3861,7 @@ BR2_PACKAGE_NUMACTL_ARCH_SUPPORTS=y
 #
 
 #
-# polkit needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
+# polkit needs a toolchain with dynamic library, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_PROCRANK_LINUX is not set
 # BR2_PACKAGE_PWGEN is not set
@@ -3621,6 +3874,10 @@ BR2_PACKAGE_NUMACTL_ARCH_SUPPORTS=y
 #
 # rauc needs a toolchain w/ wchar, threads
 #
+
+#
+# runc needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_S6 is not set
 # BR2_PACKAGE_S6_LINUX_INIT is not set
 # BR2_PACKAGE_S6_LINUX_UTILS is not set
@@ -3630,8 +3887,13 @@ BR2_PACKAGE_NUMACTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SCRYPT is not set
 
 #
+# sdbus-c++ needs systemd and a toolchain w/ C++, gcc >= 7
+#
+
+#
 # sdbusplus needs systemd and a toolchain w/ C++, gcc >= 7
 #
+# BR2_PACKAGE_SEATD is not set
 # BR2_PACKAGE_SMACK is not set
 
 #
@@ -3645,7 +3907,10 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 #
 # tpm2-abrmd needs a toolchain w/ dynamic library, wchar, threads
 #
-# BR2_PACKAGE_TPM2_TOOLS is not set
+
+#
+# tpm2-tools needs a glibc or musl toolchain w/ dynamic library, wchar
+#
 # BR2_PACKAGE_TPM2_TOTP is not set
 
 #
@@ -3653,6 +3918,7 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_UTIL_LINUX is not set
 # BR2_PACKAGE_WATCHDOG is not set
+# BR2_PACKAGE_WATCHDOGD is not set
 
 #
 # xdg-dbus-proxy needs a toolchain w/ wchar, threads
@@ -3692,6 +3958,7 @@ BR2_TARGET_ROOTFS_CPIO_NONE=y
 # BR2_TARGET_ROOTFS_CPIO_LZMA is not set
 # BR2_TARGET_ROOTFS_CPIO_LZO is not set
 # BR2_TARGET_ROOTFS_CPIO_XZ is not set
+# BR2_TARGET_ROOTFS_CPIO_ZSTD is not set
 # BR2_TARGET_ROOTFS_CPIO_UIMAGE is not set
 # BR2_TARGET_ROOTFS_CRAMFS is not set
 # BR2_TARGET_ROOTFS_EROFS is not set
@@ -3699,6 +3966,7 @@ BR2_TARGET_ROOTFS_CPIO_NONE=y
 # BR2_TARGET_ROOTFS_F2FS is not set
 BR2_TARGET_ROOTFS_INITRAMFS=y
 # BR2_TARGET_ROOTFS_JFFS2 is not set
+# BR2_TARGET_ROOTFS_OCI is not set
 # BR2_TARGET_ROOTFS_ROMFS is not set
 # BR2_TARGET_ROOTFS_SQUASHFS is not set
 # BR2_TARGET_ROOTFS_TAR is not set
@@ -3712,6 +3980,8 @@ BR2_TARGET_ROOTFS_INITRAMFS=y
 # BR2_TARGET_BAREBOX is not set
 # BR2_TARGET_BINARIES_MARVELL is not set
 # BR2_TARGET_BOOT_WRAPPER_AARCH64 is not set
+BR2_TARGET_EDK2_ARCH_SUPPORTS=y
+# BR2_TARGET_EDK2 is not set
 BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 
 #
@@ -3719,6 +3989,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 #
 # BR2_TARGET_MV_DDR_MARVELL is not set
 # BR2_TARGET_OPTEE_OS is not set
+BR2_PACKAGE_SHIM_ARCH_SUPPORTS=y
 # BR2_TARGET_SHIM is not set
 # BR2_TARGET_UBOOT is not set
 # BR2_TARGET_VEXPRESS_FIRMWARE is not set
@@ -3726,10 +3997,12 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 #
 # Host utilities
 #
+# BR2_PACKAGE_HOST_ABOOTIMG is not set
 # BR2_PACKAGE_HOST_AESPIPE is not set
 # BR2_PACKAGE_HOST_ANDROID_TOOLS is not set
 # BR2_PACKAGE_HOST_ASN1C is not set
 # BR2_PACKAGE_HOST_BABELTRACE2 is not set
+# BR2_PACKAGE_HOST_BMAP_TOOLS is not set
 # BR2_PACKAGE_HOST_BTRFS_PROGS is not set
 # BR2_PACKAGE_HOST_CHECKPOLICY is not set
 # BR2_PACKAGE_HOST_CHECKSEC is not set
@@ -3737,6 +4010,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_CRAMFS is not set
 # BR2_PACKAGE_HOST_CRYPTSETUP is not set
 # BR2_PACKAGE_HOST_DBUS_PYTHON is not set
+# BR2_PACKAGE_HOST_DELVE is not set
 # BR2_PACKAGE_HOST_DFU_UTIL is not set
 # BR2_PACKAGE_HOST_DOS2UNIX is not set
 # BR2_PACKAGE_HOST_DOSFSTOOLS is not set
@@ -3750,6 +4024,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_F2FS_TOOLS is not set
 # BR2_PACKAGE_HOST_FAKETIME is not set
 # BR2_PACKAGE_HOST_FATCAT is not set
+# BR2_PACKAGE_HOST_FIRMWARE_UTILS is not set
 # BR2_PACKAGE_HOST_FWUP is not set
 # BR2_PACKAGE_HOST_GENEXT2FS is not set
 # BR2_PACKAGE_HOST_GENIMAGE is not set
@@ -3768,6 +4043,7 @@ BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_JSMIN is not set
 BR2_PACKAGE_HOST_KMOD=y
 # BR2_PACKAGE_HOST_KMOD_GZ is not set
+# BR2_PACKAGE_HOST_KMOD_ZSTD is not set
 # BR2_PACKAGE_HOST_KMOD_XZ is not set
 # BR2_PACKAGE_HOST_LIBP11 is not set
 # BR2_PACKAGE_HOST_LLD is not set
@@ -3778,16 +4054,18 @@ BR2_PACKAGE_HOST_KMOD=y
 BR2_PACKAGE_HOST_MKPASSWD=y
 # BR2_PACKAGE_HOST_MTD is not set
 # BR2_PACKAGE_HOST_MTOOLS is not set
+# BR2_PACKAGE_HOST_NODEJS is not set
 # BR2_PACKAGE_HOST_ODB is not set
 # BR2_PACKAGE_HOST_OPENOCD is not set
 # BR2_PACKAGE_HOST_OPKG_UTILS is not set
+# BR2_PACKAGE_HOST_PAHOLE is not set
 # BR2_PACKAGE_HOST_PARTED is not set
 BR2_PACKAGE_HOST_PATCHELF=y
 # BR2_PACKAGE_HOST_PIGZ is not set
 # BR2_PACKAGE_HOST_PKGCONF is not set
 # BR2_PACKAGE_HOST_PWGEN is not set
-# BR2_PACKAGE_HOST_PYTHON is not set
 # BR2_PACKAGE_HOST_PYTHON_CYTHON is not set
+# BR2_PACKAGE_HOST_PYTHON_GREENLET is not set
 # BR2_PACKAGE_HOST_PYTHON_LXML is not set
 # BR2_PACKAGE_HOST_PYTHON_SIX is not set
 # BR2_PACKAGE_HOST_PYTHON_XLRD is not set
@@ -3796,8 +4074,10 @@ BR2_PACKAGE_HOST_QEMU_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_QEMU_SYSTEM_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_QEMU_USER_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_QEMU is not set
+# BR2_PACKAGE_HOST_QORIQ_RCW is not set
+# BR2_PACKAGE_HOST_RASPBERRYPI_USBBOOT is not set
 # BR2_PACKAGE_HOST_RAUC is not set
-# BR2_PACKAGE_HOST_RCW is not set
+# BR2_PACKAGE_HOST_RISCV_ISA_SIM is not set
 BR2_PACKAGE_HOST_RUSTC_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_RUSTC_ARCH="aarch64"
 # BR2_PACKAGE_HOST_RUSTC is not set
@@ -3805,6 +4085,7 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 # BR2_PACKAGE_HOST_SAM_BA is not set
 # BR2_PACKAGE_HOST_SDBUSPLUS is not set
 # BR2_PACKAGE_HOST_SENTRY_CLI is not set
+# BR2_PACKAGE_HOST_SLOCI_IMAGE is not set
 # BR2_PACKAGE_HOST_SQUASHFS is not set
 # BR2_PACKAGE_HOST_SWIG is not set
 # BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
@@ -3820,9 +4101,135 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 
 #
+# Legacy options removed in 2022.02
+#
+# BR2_sh2a is not set
+BR2_TARGET_ROOTFS_OCI_ENTRYPOINT_ARGS=""
+# BR2_PACKAGE_LIBCURL_LIBNSS is not set
+# BR2_PACKAGE_WESTON_DEFAULT_FBDEV is not set
+# BR2_PACKAGE_WESTON_FBDEV is not set
+# BR2_PACKAGE_PYTHON_PYCLI is not set
+# BR2_PACKAGE_LINUX_TOOLS_BPFTOOL is not set
+# BR2_TARGET_UBOOT_NEEDS_PYTHON2 is not set
+# BR2_PACKAGE_PYTHON_FUNCTOOLS32 is not set
+# BR2_PACKAGE_PYTHON_ENUM34 is not set
+# BR2_PACKAGE_PYTHON_ENUM is not set
+# BR2_PACKAGE_PYTHON_DIALOG is not set
+# BR2_PACKAGE_PYTHON_CONFIGOBJ is not set
+# BR2_PACKAGE_PYTHON_YIELDFROM is not set
+# BR2_PACKAGE_PYTHON_TYPING is not set
+# BR2_PACKAGE_PYTHON_SUBPROCESS32 is not set
+# BR2_PACKAGE_PYTHON_SINGLEDISPATCH is not set
+# BR2_PACKAGE_PYTHON_PYRO is not set
+# BR2_PACKAGE_PYTHON_PYPCAP is not set
+# BR2_PACKAGE_PYTHON_PATHLIB2 is not set
+# BR2_PACKAGE_PYTHON_PAM is not set
+# BR2_PACKAGE_PYTHON_NFC is not set
+# BR2_PACKAGE_PYTHON_MAD is not set
+# BR2_PACKAGE_PYTHON_IPADDRESS is not set
+# BR2_PACKAGE_PYTHON_IPADDR is not set
+# BR2_PACKAGE_PYTHON_ID3 is not set
+# BR2_PACKAGE_PYTHON_FUTURES is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SSL_MATCH_HOSTNAME is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SHUTIL_GET_TERMINAL_SIZE is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_ABC is not set
+# BR2_PACKAGE_PYTHON is not set
+# BR2_TARGET_UBOOT_ZYNQ_IMAGE is not set
+# BR2_PACKAGE_RPI_BT_FIRMWARE is not set
+# BR2_PACKAGE_RPI_WIFI_FIRMWARE is not set
+# BR2_PACKAGE_HOST_GDB_PYTHON is not set
+# BR2_PACKAGE_GSTREAMER1_MM is not set
+# BR2_KERNEL_HEADERS_5_14 is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_FUNCTOOLS_LRU_CACHE is not set
+# BR2_PACKAGE_CIVETWEB_WITH_LUA is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_DRIVER is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R6P2 is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R8P1 is not set
+# BR2_PACKAGE_QT5WEBKIT_EXAMPLES is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_GLIBC_BLEEDING_EDGE is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_MUSL_BLEEDING_EDGE is not set
+# BR2_PACKAGE_IPUTILS_TFTPD is not set
+# BR2_PACKAGE_IPUTILS_TRACEROUTE6 is not set
+# BR2_PACKAGE_LIBMEDIAART_BACKEND_NONE is not set
+# BR2_PACKAGE_MPD_UPNP is not set
+
+#
+# Legacy options removed in 2021.11
+#
+# BR2_OPENJDK_VERSION_LTS is not set
+# BR2_OPENJDK_VERSION_LATEST is not set
+# BR2_PACKAGE_MPD_TIDAL is not set
+# BR2_PACKAGE_MROUTED_RSRR is not set
+# BR2_BINUTILS_VERSION_CSKY is not set
+# BR2_GCC_VERSION_CSKY is not set
+# BR2_PACKAGE_CANFESTIVAL is not set
+# BR2_PACKAGE_NMAP_NDIFF is not set
+# BR2_GDB_VERSION_8_3 is not set
+# BR2_PACKAGE_PYTHON_MELD3 is not set
+# BR2_PACKAGE_STRONGSWAN_EAP is not set
+# BR2_PACKAGE_GNURADIO_PAGER is not set
+# BR2_KERNEL_HEADERS_5_11 is not set
+# BR2_KERNEL_HEADERS_5_12 is not set
+# BR2_KERNEL_HEADERS_5_13 is not set
+
+#
+# Legacy options removed in 2021.08
+#
+BR2_TARGET_GRUB2_BUILTIN_MODULES=""
+BR2_TARGET_GRUB2_BUILTIN_CONFIG=""
+# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_MCRYPT is not set
+# BR2_PACKAGE_PHP_EXT_MCRYPT is not set
+# BR2_BINUTILS_VERSION_2_34_X is not set
+# BR2_PACKAGE_LIBSOIL is not set
+# BR2_PACKAGE_CLAPACK is not set
+# BR2_PACKAGE_SPIDERMONKEY is not set
+# BR2_PACKAGE_KODI_LIBVA is not set
+# BR2_PACKAGE_PYTHON_COHERENCE is not set
+# BR2_PACKAGE_PHP_EXT_XMLRPC is not set
+# BR2_GCC_VERSION_8_X is not set
+
+#
+# Legacy options removed in 2021.05
+#
+# BR2_PACKAGE_UDISKS_LVM2 is not set
+# BR2_PACKAGE_LVM2_APP_LIBRARY is not set
+# BR2_PACKAGE_LVM2_LVMETAD is not set
+# BR2_PACKAGE_MONKEY is not set
+# BR2_PACKAGE_DOCKER_CONTAINERD is not set
+# BR2_PACKAGE_IOSTAT is not set
+# BR2_PACKAGE_SCONESERVER_HTTP_SCONESITE_IMAGE is not set
+# BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_EVDEV is not set
+# BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_KBD is not set
+# BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_MOUSE is not set
+# BR2_PACKAGE_MESA3D_OSMESA_CLASSIC is not set
+# BR2_PACKAGE_MESA3D_DRI_DRIVER_SWRAST is not set
+# BR2_PACKAGE_KODI_SCREENSAVER_CRYSTALMORPH is not set
+
+#
+# Legacy options removed in 2021.02
+#
+# BR2_PACKAGE_MPD_AUDIOFILE is not set
+# BR2_PACKAGE_AUDIOFILE is not set
+# BR2_BINUTILS_VERSION_2_33_X is not set
+# BR2_PACKAGE_LIBUPNP18 is not set
+# BR2_PACKAGE_BOA is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_IMX_SDMA is not set
+# BR2_GDB_VERSION_8_2 is not set
+# BR2_PACKAGE_HOST_RCW is not set
+# BR2_KERNEL_HEADERS_5_9 is not set
+# BR2_KERNEL_HEADERS_5_8 is not set
+# BR2_powerpc_601 is not set
+# BR2_PACKAGE_TI_SGX_LIBGBM is not set
+# BR2_PACKAGE_IPSEC_TOOLS is not set
+
+#
 # Legacy options removed in 2020.11
 #
-# BR2_PACKAGE_LIBUPNP18 is not set
+# BR2_PACKAGE_GPSD_FIXED_PORT_SPEED is not set
+# BR2_PACKAGE_GPSD_RECONFIGURE is not set
+# BR2_PACKAGE_GPSD_CONTROLSEND is not set
 # BR2_PACKAGE_OPENCV is not set
 # BR2_PACKAGE_LIBCROCO is not set
 # BR2_PACKAGE_BELLAGIO is not set

--- a/guests/linux/make.mk
+++ b/guests/linux/make.mk
@@ -11,7 +11,7 @@ $(linux_src):
 	git -C $(linux_src) apply $(linux_patches)
 
 buildroot_repo:=https://github.com/buildroot/buildroot.git
-buildroot_version:=2020.11.3
+buildroot_version:=2022.02.2
 buildroot_src:=$(wrkdir_src)/buildroot-$(ARCH)-$(linux_version)
 buildroot_defcfg:=$(bao_demos)/guests/linux/buildroot/$(ARCH).config
 


### PR DESCRIPTION
Ubuntu 22.04 LTS build fix

Fixed the building bug for the Ubuntu 22.04 LTS. Updated the aarch64.config file on /bao-demos/guests/linux/buildroot, and changed the buildroot version (to 2022.02.2), to match the latest version of the m4 package (1.4.19).

Issue: #-
Signed-off-by: Diogo Costa <diogoandreveigacosta@gmail.com>