### PR TITLE
fix typo in RPI4B README file

### DIFF
--- a/platforms/rpi4/README.md
+++ b/platforms/rpi4/README.md
@@ -94,7 +94,7 @@ fatload mmc 0 0x200000 bao.bin; go 0x200000
 You should see the firmare, bao and its guests printing on the UART.
 
 At this point, depending on your demo, you might be able connect to one of the 
-guests via ssh by connecting to the board's ethernet RJ54 socket.
+guests via ssh by connecting to the board's ethernet RJ45 socket.
 
 
 <!--- instruction#end -->


### PR DESCRIPTION
Fix typo in rpi4b readme "RJ54" to "RJ45"