### PR TITLE
platforms: opensbi: switch the default branch

### DIFF
--- a/platforms/opensbi.mk
+++ b/platforms/opensbi.mk
@@ -1,5 +1,5 @@
 opensbi_repo:=https://github.com/bao-project/opensbi.git
-opensbi_version:=bao
+opensbi_version:=bao/master
 opensbi_src:=$(wrkdir_src)/opensbi
 
 $(opensbi_src):


### PR DESCRIPTION
Trying to build the demo `baremetal` project for `qemu-riscv64-virt` will fail when trying to clone the `bao` branch on your `opensbi` fork -- it no longer exists.

Switch `opensbi_version` from `bao` to `bao/master`

Signed-off-by: Roberto Medina <robertoxmed@gmail.com>