### PR TITLE
fix(fvp): fixed instructions to use the fvp model

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Build the firmware and deploy the system according to the target platform:
 
 | Tool                    | Version |
 | ----------------------- | ------- |
+| arm-none-eabi-gcc       | 11.3.1  |
 | aarch64-none-elf-gcc    | 11.2.1  |
 | riscv64-unknown-elf-gcc | 10.2.0  |
 | make                    | 4.2.1   |

--- a/platforms/fvp-r/README.md
+++ b/platforms/fvp-r/README.md
@@ -7,7 +7,7 @@
 **NOTE**
 
 If you already have FVP_BaseR_AEMv8R installed please make sure you are
-using version ??? or higher. If so, you can skip this step
+using version 11.20.15 or higher. If so, you can skip this step.
 
 ---
 
@@ -15,18 +15,28 @@ Download and extract the model:
 
 ```
 curl -L https://developer.arm.com/-/media/Files/downloads/ecosystem-models/FVP_Base_AEMv8R_11.20_15_Linux64.tgz | tar xz -C $BAO_DEMOS_WRKDIR_PLAT
-export PATH=$PATH:$BAO_DEMOS_WRKDIR_PLAT/Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3
+export PATH=$PATH:$BAO_DEMOS_WRKDIR_PLAT/AEMv8R_base_pkg/models/Linux64_GCC-9.3
 ```
 
-## 4) Run FVP
+## 2) Download and install XTerm
+
+---
+
+Download and install XTerm:
+
+```
+sudo apt-get install xterm
+```
+
+## 3) Run FVP
 
 ```
 FVP_BaseR_AEMv8R \
 	-C gic_distributor.has-two-security-states=0 \
 	-C cluster0.gicv3.cpuintf-mmap-access-level=2 \
 	-C cluster0.gicv3.SRE-EL2-enable-RAO=1 \
-    -C cluster0.has_aarch64=$(($ARCH==aarch64)) \
-	-C cluster0.VMSA_supported=$(($ARCH==aarch64)) \
+    -C cluster0.has_aarch64=$(([[ $ARCH == aarch64 ]]) && echo 1 || echo 0) \
+	-C cluster0.VMSA_supported=$(([[ $ARCH == aarch64 ]]) && echo 1 || echo 0) \
 	-C bp.smsc_91c111.enabled=true -C bp.hostbridge.userNetworking=true \
 	-C bp.hostbridge.userNetSubnet=192.168.42.0/24 -C bp.hostbridge.userNetPorts=127.0.0.1:5555=22 \
     --data==$BAO_DEMOS_WRKDIR_IMGS/bao.bin@0x0
@@ -40,4 +50,3 @@ The FVP AEM models are quite slow. Demos featuring heavier guests like Linux
 might take some time to fully boot up.
 <!--- instruction#end -->
 ---
-


### PR DESCRIPTION
This PR fixes the instructions to use the FVP model (in aarch64 and aarch32), as well as warning the user of the need to have the _arm-none-eabi-gcc_ compiler.