### PR TITLE
feat(ipc_interrupt): enable ipc delivery via interrupt in Linux

### DIFF
--- a/demos/linux+freertos/devicetrees/fvp-a-aarch32/linux.dts
+++ b/demos/linux+freertos/devicetrees/fvp-a-aarch32/linux.dts
@@ -86,7 +86,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/fvp-a/linux.dts
+++ b/demos/linux+freertos/devicetrees/fvp-a/linux.dts
@@ -86,7 +86,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/fvp-r/linux.dts
+++ b/demos/linux+freertos/devicetrees/fvp-r/linux.dts
@@ -86,7 +86,7 @@
         reg = <0x0 0x70000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/imx8qm/linux.dts
+++ b/demos/linux+freertos/devicetrees/imx8qm/linux.dts
@@ -259,7 +259,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		interrupt-parent = <&gic>;
 		id = <0>;
     };

--- a/demos/linux+freertos/devicetrees/qemu-aarch64-virt/linux.dts
+++ b/demos/linux+freertos/devicetrees/qemu-aarch64-virt/linux.dts
@@ -120,7 +120,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/qemu-riscv64-virt/linux.dts
+++ b/demos/linux+freertos/devicetrees/qemu-riscv64-virt/linux.dts
@@ -135,7 +135,7 @@
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
 		interrupt-parent = <&plic>;
-        interrupts = <52>;
+        interrupts = <20>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/rpi4/linux.dts
+++ b/demos/linux+freertos/devicetrees/rpi4/linux.dts
@@ -108,7 +108,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/tx2/linux.dts
+++ b/demos/linux+freertos/devicetrees/tx2/linux.dts
@@ -183,7 +183,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/zcu104/linux.dts
+++ b/demos/linux+freertos/devicetrees/zcu104/linux.dts
@@ -138,7 +138,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-		interrupts = <0 52 1>;
+		interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/fvp-a-aarch32/linux.dts
+++ b/demos/linux+zephyr/devicetrees/fvp-a-aarch32/linux.dts
@@ -86,7 +86,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/fvp-a/linux.dts
+++ b/demos/linux+zephyr/devicetrees/fvp-a/linux.dts
@@ -79,7 +79,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/fvp-r/linux.dts
+++ b/demos/linux+zephyr/devicetrees/fvp-r/linux.dts
@@ -80,7 +80,7 @@
         reg = <0x0 0x70000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/imx8qm/linux.dts
+++ b/demos/linux+zephyr/devicetrees/imx8qm/linux.dts
@@ -259,7 +259,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		interrupt-parent = <&gic>;
 		id = <0>;
     };

--- a/demos/linux+zephyr/devicetrees/qemu-aarch64-virt/linux.dts
+++ b/demos/linux+zephyr/devicetrees/qemu-aarch64-virt/linux.dts
@@ -114,7 +114,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/rpi4/linux.dts
+++ b/demos/linux+zephyr/devicetrees/rpi4/linux.dts
@@ -108,7 +108,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/tx2/linux.dts
+++ b/demos/linux+zephyr/devicetrees/tx2/linux.dts
@@ -183,7 +183,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-        interrupts = <0 52 1>;
+        interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/devicetrees/zcu104/linux.dts
+++ b/demos/linux+zephyr/devicetrees/zcu104/linux.dts
@@ -138,7 +138,7 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-		interrupts = <0 52 1>;
+		interrupts = <0 20 1>;
 		id = <0>;
     };
 

--- a/demos/linux+zephyr/zephyr/app/src/main.c
+++ b/demos/linux+zephyr/zephyr/app/src/main.c
@@ -41,6 +41,7 @@ void uart_rx_handler() {
     snprintf(msg, MSG_SIZE,
         "zephyr has received %ld uart interrupts!\n", irq_count);
     bao_ipcshmem_write(shmem, msg, strnlen(msg, MSG_SIZE)+1);
+    bao_ipcshmem_notify(shmem);
 }
 
 void shmem_irq_handler(const struct device *dev) {

--- a/guests/linux/patches/v6.1/0003-bao-ipcshmem-receive-ipc-message-from-ipc-interrupt.patch
+++ b/guests/linux/patches/v6.1/0003-bao-ipcshmem-receive-ipc-message-from-ipc-interrupt.patch
@@ -1,0 +1,60 @@
+From be0d07b654e3e1011e87df84709155683120acd3 Mon Sep 17 00:00:00 2001
+From: Clay Chang <clay.chang@gmail.com>
+Date: Mon, 17 Jul 2023 18:49:55 +0800
+Subject: [PATCH 3/3] bao-ipcshmem: receive ipc message from ipc interrupt
+
+---
+ drivers/bao/bao-ipcshmem.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/drivers/bao/bao-ipcshmem.c b/drivers/bao/bao-ipcshmem.c
+index e9cc304ea..9af4f6e37 100644
+--- a/drivers/bao/bao-ipcshmem.c
++++ b/drivers/bao/bao-ipcshmem.c
+@@ -181,6 +181,15 @@ static struct file_operations bao_ipcshmem_fops = {
+     .release = bao_ipcshmem_release_fops
+ };
+ 
++static irqreturn_t ipc_message_handler(int irq, void *data)
++{
++    struct bao_ipcshmem *bao = (struct bao_ipcshmem *)data;
++
++    pr_info("ipc message: %s", (char *)bao->read_base);
++
++    return IRQ_HANDLED;
++}
++
+ int bao_ipcshmem_register(struct platform_device *pdev)
+ {
+     int ret = 0;
+@@ -194,6 +203,7 @@ int bao_ipcshmem_register(struct platform_device *pdev)
+     bool rd_in_range, wr_in_range, disjoint;
+     void* shmem_base_addr = NULL;
+     int id = -1;
++    unsigned int irq;
+     struct bao_ipcshmem *bao;
+ 
+     r = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+@@ -241,6 +251,13 @@ int bao_ipcshmem_register(struct platform_device *pdev)
+     bao->write_base = shmem_base_addr + write_offset;
+     bao->physical_base = (void *)r->start;
+ 
++    irq = platform_get_irq(pdev, 0);
++    ret = devm_request_irq(&pdev->dev, irq, ipc_message_handler, IRQF_TRIGGER_RISING, bao->label, (void *)bao);
++    if (ret != 0) {
++        pr_err("failed to request irq: ret=%d\n", ret);
++        goto err_unmap;
++    }
++
+     cdev_init(&bao->cdev, &bao_ipcshmem_fops);
+     bao->cdev.owner = owner;
+ 
+@@ -322,4 +339,5 @@ module_exit(bao_ipcshmem_exit);
+ MODULE_LICENSE("GPL");
+ MODULE_AUTHOR("David Cerdeira");
+ MODULE_AUTHOR("José Martins");
++MODULE_AUTHOR("Clay Chang");
+ MODULE_DESCRIPTION("bao ipc through shared-memory sample driver");
+-- 
+2.34.1
+


### PR DESCRIPTION
- register ipc_message_handler to receive ipc notification in
  bao-ipcshmem driver
- modify configs to define interrupt_offset in Linux VM
- call bao_ipcshmem_notify in uart_rx_handler in Zephyr

On success, a message like below will appear in dmesg:

[   12.881296] ipc message: freertos has received 1 uart interrupts!

Tested:
- qemu-aarch64-virt
  - linux+freertos
  - linux+zephyr
- rpi4
  - linux+freertos