### PR TITLE
update(plat/zcu): download firmware from github and build using bootgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ newer/compatible versions of the tools and software listed in
 ```
 sudo apt install build-essential bison flex git libssl-dev ninja-build \
     u-boot-tools pandoc libslirp-dev pkg-config libglib2.0-dev libpixman-1-dev \
-    gettext-base curl xterm cmake python3-pip
+    gettext-base curl xterm cmake python3-pip xilinx-bootgen
 
 pip3 install pykwalify packaging pyelftools
 ```

--- a/platforms/zcu104/README.md
+++ b/platforms/zcu104/README.md
@@ -1,25 +1,16 @@
 # Xilinx ZCU10X
 
-<!--- instruction#1 -->
 ## 1) Get firmware
 
-Download latest pre-built Zynq UltraScale+ MPSoC Firmware for your target 
-platform (you will need to sign-in to Xilinx account and provide further 
-personal information) to $BAO_DEMOS_WRKDIR_SRC:
-
-* [ZCU102](https://www.xilinx.com/member/forms/download/xef.html?filename=2022.2_zcu102_release.tar.xz)
-* [ZCU104](https://www.xilinx.com/member/forms/download/xef.html?filename=2022.2_zcu104_release.tar.xz)
-
-<!--- instruction#end -->
-
-Extract it  to $BAO_DEMOS_WRKDIR_SRC: 
+Download latest pre-built Zynq UltraScale+ MPSoC Firmware and use *bootgen*
+to build the firmware binary:
 
 ```
-tar xvfm $BAO_DEMOS_WRKDIR_SRC/2020.2-$PLATFORM-release.tar.xz\
-    -C $BAO_DEMOS_WRKDIR_PLAT --wildcards "*BOOT.BIN" --strip-components=1
+git clone https://github.com/Xilinx/soc-prebuilt-firmware.git --depth 1 \
+    --branch xilinx_v2023.1 $BAO_DEMOS_WRKDIR_SRC/zcu-firmware
+cd $BAO_DEMOS_WRKDIR_SRC/zcu-firmware/$PLATFORM-zynqmp && 
+    bootgen -arch zynqmp -image bootgen.bif -w -o $BAO_DEMOS_WRKDIR_PLAT/BOOT.BIN
 ```
-
-Alternatively, you can [build the firmware from scratch][firmware-from-scratch]. 
 
 ## 2) Prepare a U-boot image
 
@@ -30,7 +21,7 @@ mkimage -n bao_uboot -A arm64 -O linux -C none -T kernel -a 0x200000\
     -e 0x200000 -d $BAO_DEMOS_WRKDIR_IMGS/bao.bin $BAO_DEMOS_WRKDIR_IMGS/bao.img
 ```
 
-<!--- instruction#2 -->
+<!--- instruction#1 -->
 ## 3) Setup SD card
 
 After [preparing your sd card](../../platforms/sdcard.md), copy the firmware and 
@@ -42,7 +33,7 @@ cp $BAO_DEMOS_WRKDIR_IMGS/bao.img $BAO_DEMOS_SDCARD
 umount $BAO_DEMOS_SDCARD
 ```
 
-<!--- instruction#3 -->
+<!--- instruction#2 -->
 ## 4) Setup board
 
 First make sure you have the board configured to boot from the SD card. If you 
@@ -68,7 +59,7 @@ screen /dev/ttyUSB1 115200
 
 Turn on/reset your board.
 
-<!--- instruction#4 -->
+<!--- instruction#3 -->
 ## 5) Run u-boot commands
 
 Quickly press any key to skip autoboot. If not possibly press `ctrl-c` until 

--- a/platforms/zcu104/make.mk
+++ b/platforms/zcu104/make.mk
@@ -1,21 +1,23 @@
 ARCH:=aarch64
 
 boot_bin:=$(wrkdir_plat_imgs)/BOOT.BIN
-prebuilt_images_tar:=$(wrkdir_src)/2022.2_$(PLATFORM)_release.tar.xz
+prebuilt_images_src:=$(wrkdir_src)/zcu-firmware
+prebuilt_images_repo:=https://github.com/Xilinx/soc-prebuilt-firmware.git
+prebuilt_images_version:=xilinx_v2023.1
 instuctions:=$(bao_demos)/platforms/$(PLATFORM)/README.md
 bao_uboot_image:=$(wrkdir_demo_imgs)/bao.img
 
-$(prebuilt_images_tar):
-	$(call print-instructions, $(instuctions), 1, false)
+$(prebuilt_images_src):
+	@git clone --depth 1 --branch $(prebuilt_images_version) $(prebuilt_images_repo) $@
 
-$(boot_bin): $(prebuilt_images_tar)
-	@tar xfvm $< -C $(dir $@) --wildcards "*BOOT.BIN" --strip-components=1
+$(boot_bin): $(prebuilt_images_src)
+	@cd $</$(PLATFORM)-zynqmp && bootgen -arch zynqmp -image bootgen.bif -w -o $@
 
 $(bao_uboot_image): $(bao_image)
 	@mkimage -n bao_uboot -A arm64 -O linux -C none -T kernel -a 0x200000\
 		-e 0x200000 -d $(bao_image) $@
  
 platform: $(bao_image) $(boot_bin) $(bao_uboot_image) 
+	$(call print-instructions, $(instuctions), 1, false)
 	$(call print-instructions, $(instuctions), 2, false)
-	$(call print-instructions, $(instuctions), 3, false)
-	$(call print-instructions, $(instuctions), 4, true)
+	$(call print-instructions, $(instuctions), 3, true)


### PR DESCRIPTION
Xilinx now provides the pre-built firmware in a github repository instead of via direct download. Also, it does not provide the final *BOOT.BIN*, which has to be built using the xilinx-bootgen tool.