### PR TITLE
update(plat/qemu): cmd requires net=IP_ADDR/RANGE for SSH to run properly

### DIFF
--- a/platforms/qemu-aarch64-virt/README.md
+++ b/platforms/qemu-aarch64-virt/README.md
@@ -81,7 +81,8 @@ qemu-system-aarch64 -nographic\
    -cpu cortex-a53 -smp 4 -m 4G\
    -bios $BAO_DEMOS_WRKDIR/imgs/$PLATFORM/flash.bin \
    -device loader,file="$BAO_DEMOS_WRKDIR_IMGS/bao.bin",addr=0x50000000,force-raw=on\
-   -device virtio-net-device,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:5555-:22\
+   -device virtio-net-device,netdev=net0\
+   -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\
    -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3
 ```
 

--- a/platforms/qemu-riscv64-virt/README.md
+++ b/platforms/qemu-riscv64-virt/README.md
@@ -42,7 +42,8 @@ cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.elf\
  qemu-system-riscv64 -nographic\
     -M virt -cpu rv64 -m 4G -smp 4\
     -bios $BAO_DEMOS_WRKDIR_IMGS/opensbi.elf\
-    -device virtio-net-device,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:5555-:22\
+    -device virtio-net-device,netdev=net0 \
+    -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\
     -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3 -S
 ```
 


### PR DESCRIPTION
Without this SSH connection will hang, until is reset by peer (timeout).

This matches the makefile command present in the the makefile on the same directory.

This fix was originally submitted by @ElectroQuanta in #40.