### PR TITLE
chore: fix a typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,5 @@ clean: guests_clean bao_clean platform_clean
 distclean:
 	rm -rf $(wrkdir)
 
-.PHONY: all clean guests bao paltform
+.PHONY: all clean guests bao platform
 .NOTPARALLEL:


### PR DESCRIPTION
I found there was a typo in the Makefile.
I just quickly fixed it.