### PR TITLE
update(rpi4_fw): update raspberry pi 4 firmware target branch

### DIFF
--- a/platforms/rpi4/README.md
+++ b/platforms/rpi4/README.md
@@ -7,7 +7,7 @@ Download the latest firmware files for Raspberry Pi:
 ```
 export BAO_DEMOS_FW=$BAO_DEMOS_WRKDIR_PLAT/firmware 
 git clone https://github.com/raspberrypi/firmware.git $BAO_DEMOS_FW\
-    --depth 1 --branch 1.20210201
+    --depth 1 --branch 1.20240306
 ```
 
 ## 2) Build U-boot

--- a/platforms/rpi4/make.mk
+++ b/platforms/rpi4/make.mk
@@ -1,7 +1,7 @@
 ARCH:=aarch64
 
 firmware_repo:=https://github.com/raspberrypi/firmware.git
-firmware_version:=1.20230405
+firmware_version:=1.20240306
 firmware_images:=$(wrkdir_plat_imgs)/firmware
 
 $(firmware_images):


### PR DESCRIPTION
This PR updates the firmware version for the Raspberry Pi 4 target branch from `1.20230405` (automatic make, in readme it was the `1.20210201`) to `1.20240306`. The change addresses compatibility issues on newer Raspberry Pi 4 boards, ensuring functionality across all supported hardware configurations.