### PR TITLE
fix: add missing dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ newer/compatible versions of the tools and software listed in
 ```
 sudo apt install build-essential bison flex git libssl-dev ninja-build \
     u-boot-tools pandoc libslirp-dev pkg-config libglib2.0-dev libpixman-1-dev \
-    gettext-base curl xterm cmake python3-pip xilinx-bootgen
+    gettext-base curl xterm cmake python3-pip xilinx-bootgen file cpio
 
 pip3 install pykwalify packaging pyelftools
 ```


### PR DESCRIPTION
When building a demo inside of a docker container (especially [ubuntu:latest](https://hub.docker.com/_/ubuntu)) two additional dependencies must be downloaded through `apt` for `make` to work properly - `file` and `cpio`.

```
$ echo $PLATFORM
  qemu-aarch64-virt
$ echo $DEMO
  linux+zephyr
$ echo $CROSS_COMPILE
  /home/user/Desktop/bao/bao-demo/toolchain/arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf/bin/aarch64-none-elf-
```


```
You must install '/usr/bin/file' on your build machine
make[1]: *** [support/dependencies/dependencies.mk:27: dependencies] Error 1
make[1]: Leaving directory '/home/user/Desktop/bao/bao-demo/wrkdir/srcs/buildroot-aarch64-v6.1'
make: *** [/home/user/Desktop/bao/bao-demo/guests/linux/make.mk:28: /home/user/Desktop/bao/bao-demo/wrkdir/srcs/buildroot-aarch64-v6.1/output/images/Image-qemu-aarch64-virt] Error 2
```

```
make[2]: warning: -j1 forced in submake: resetting jobserver mode.
make[2]: Leaving directory '/home/user/Desktop/bao/bao-demo/wrkdir/srcs/buildroot-aarch64-v6.1'
You must install 'cpio' on your build machine
make[1]: *** [support/dependencies/dependencies.mk:27: dependencies] Error 1
make[1]: Leaving directory '/home/user/Desktop/bao/bao-demo/wrkdir/srcs/buildroot-aarch64-v6.1'
make: *** [/home/user/Desktop/bao/bao-demo/guests/linux/make.mk:28: /home/user/Desktop/bao/bao-demo/wrkdir/srcs/buildroot-aarch64-v6.1/output/images/Image-qemu-aarch64-virt] Error 2
```