### PR TITLE
Add FreeRTOS+Baremetal demo for RH850

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ environment+=BAO_DEMOS_SDCARD=/media/$$USER/boot
 all: platform
 
 bao_repo:=https://github.com/bao-project/bao-hypervisor
-bao_version:=1a78ca35e21f25b1196b8ac11aff59f35427cc8f
+bao_version:=2956f48f8a56a147303521315b34325014affbcd
 bao_src:=$(wrkdir_src)/bao
 bao_cfg_repo:=$(wrkdir_demo_imgs)/config
 wrkdirs+=$(bao_cfg_repo)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ systems and targeting several supported platforms. The available demos are:
 * [Dual-guest Linux+Zephyr](demos/linux+zephyr/README.md)
 * [Dual-guest Zephyr+Baremetal](demos/zephyr+baremetal/README.md)
 * [Dual-guest Nuttx+Baremetal](demos/nuttx+baremetal/README.md)
+* [Dual-guest FreeRTOS+Baremetal](demos/freertos+baremetal/README.md)
 * [Four-guest VirtIO Demo](demos/virtio/README.md)
 
 ---
@@ -189,6 +190,7 @@ Build guests according to the target demo:
 * [Dual-guest Linux+FreeRTOS](demos/linux+freertos/README.md)
 * [Dual-Guest Linux+Zephyr](demos/linux+zephyr/README.md)
 * [Dual-Guest Zephyr+Baremetal](demos/zephyr+baremetal/README.md)
+* [Dual-Guest FreeRTOS+Baremetal](demos/freertos+baremetal/README.md)
 * [Dual-Guest Torizon OS+FreeRTOS](demos/torizonos+freertos/README.md)
 * [Dual-Guest Nuttx+Baremetal](demos/nuttx+baremetal/README.md)
 
@@ -200,7 +202,7 @@ Clone Bao's repo to the working directory:
 ```
 export BAO_DEMOS_BAO=$BAO_DEMOS_WRKDIR_SRC/bao
 git clone https://github.com/bao-project/bao-hypervisor $BAO_DEMOS_BAO
-(cd $BAO_DEMOS_BAO && git checkout 1a78ca35e21f25b1196b8ac11aff59f35427cc8f)
+(cd $BAO_DEMOS_BAO && git checkout 2956f48f8a56a147303521315b34325014affbcd)
 ```
 
 Copy your config to the working directory:
@@ -302,28 +304,28 @@ Build the firmware and deploy the system according to the target platform:
 
 ## Appendix II
 
-|                   | baremetal | linux+freertos | linux+zephyr | zephyr+baremetal | virtio | torizonos+freertos | nuttx+baremetal |
-| ----------------- | --------- | -------------- | ------------ | ---------------- | ------ | ------------------ | --------------- |
-| zcu102            | x         | x              |              |                  | x      |                    |                 |
-| zcu104            | x         | x              |              |                  | x      |                    |                 |
-| imx8qm            | x         | x              |              |                  |        |                    |                 |
-| s32g3             | x         | x              |              |                  |        |                    |                 |
-| tx2               | x         | x              |              |                  |        |                    |                 |
-| rpi4              | x         | x              | x            |                  | x      |                    |                 |
-| qemu-aarch64-virt | x         | x              | x            |                  | x      |                    |                 |
-| fvp-a             | x         | x              | x            | x                |        |                    |                 |
-| fvp-a-aarch32     | x         | x              | x            | x                |        |                    |                 |
-| fvp-r             | x         | x              | x            | x                |        |                    |                 |
-| fvp-r-aarch32     | x         |                |              | x                |        |                    |                 |
-| mps3-an536        | x         |                |              | x                |        |                    |                 |
-| s32z270           | x         |                |              | x                |        |                    |                 |
-| qemu-riscv64-virt | x         | x              |              |                  | x      |                    |                 |
-| qemu-riscv32-virt | x         | x              |              |                  |        |                    |                 |
-| k3-com260         | x         | x              |              |                  |        |                    |                 |
-| rh850-u2a16       | x         |                |              |                  |        |                    |                 |
-| tc4dx             | x         |                |              |                  |        |                    |                 |
-| e3650             | x         |                |              |                  |        |                    | x               |
-| imx8mp-verdin     | x         | x              |              |                  |        | x                  |                 |
+|                   | baremetal | linux+freertos | linux+zephyr | zephyr+baremetal | virtio | torizonos+freertos | freertos+baremetal | nuttx+baremetal |
+| ----------------- | --------- | -------------- | ------------ | ---------------- | ------ | ------------------ | ------------------ | --------------- |
+| zcu102            | x         | x              |              |                  | x      |                    |                    |                 |
+| zcu104            | x         | x              |              |                  | x      |                    |                    |                 |
+| imx8qm            | x         | x              |              |                  |        |                    |                    |                 |
+| s32g3             | x         | x              |              |                  |        |                    |                    |                 |
+| tx2               | x         | x              |              |                  |        |                    |                    |                 |
+| rpi4              | x         | x              | x            |                  | x      |                    |                    |                 |
+| qemu-aarch64-virt | x         | x              | x            |                  | x      |                    |                    |                 |
+| fvp-a             | x         | x              | x            | x                |        |                    |                    |                 |
+| fvp-a-aarch32     | x         | x              | x            | x                |        |                    |                    |                 |
+| fvp-r             | x         | x              | x            | x                |        |                    |                    |                 |
+| fvp-r-aarch32     | x         |                |              | x                |        |                    |                    |                 |
+| mps3-an536        | x         |                |              | x                |        |                    |                    |                 |
+| s32z270           | x         |                |              | x                |        |                    |                    |                 |
+| qemu-riscv64-virt | x         | x              |              |                  | x      |                    |                    |                 |
+| qemu-riscv32-virt | x         | x              |              |                  |        |                    |                    |                 |
+| k3-com260         | x         | x              |              |                  |        |                    |                    |                 |
+| rh850-u2a16       | x         |                |              |                  |        |                    | x                  |                 |
+| tc4dx             | x         |                |              |                  |        |                    |                    |                 |
+| e3650             | x         |                |              |                  |        |                    |                    | x               |
+| imx8mp-verdin     | x         | x              |              |                  |        | x                  |                    |                 |
 
 ---
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -7,6 +7,7 @@ The following demos are available:
 * [Dual-Guest Linux+Zephyr](linux+zephyr/README.md)
 * [Dual-Guest NuttX+Baremetal](nuttx+baremetal/README.md)
 * [Dual-Guest Zephyr+Baremetal](zephyr+baremetal/README.md)
+* [Dual-Guest FreeRTOS+Baremetal](freertos+baremetal/README.md)
 
 More demos, showcasing different Bao features, guests and configurations will
 be available in the future.

--- a/demos/freertos+baremetal/README.md
+++ b/demos/freertos+baremetal/README.md
@@ -1,0 +1,62 @@
+# FreeRTOS + Baremetal Demo
+
+This demo features two guests running on top of Bao: **FreeRTOS** and a **Baremetal app**. The two guests can communicate via a shared memory object which includes a shared memory region and a notification mechanism in the form of a hardware interrupt.
+
+One of the platform's cores is assigned to FreeRTOS, while all remaining cores are assigned to the Baremetal app.
+
+> :information_source: This demo is only available in platforms featuring at least two UART peripherals, where one is assigned to the FreeRTOS and the other to the Baremetal app.
+
+The Baremetal app is configured with a periodic timer interrupt in the first vCPU that starts an IPI chain to the remaining vCPUs. Additionally, the Baremetal app configures an UART RX interrupt. Every time it receives a character, it prints a message and copies the received character to the shared memory region and sends a notification to FreeRTOS.
+
+The FreeRTOS guest is configured with two tasks and an UART RX interrupt which prints a message every time a character is received via console. When FreeRTOS receives a notification from the Baremetal app, it parses the received character and performs the corresponding operation in a local counter:
+- `i`/`I`: Increments the counter
+- `d`/`D`: Decrements the counter
+- `c`/`C`: Clears the counter
+- *others*: unsupported option
+
+## Building the Guests
+
+To build FreeRTOS and the Baremetal app, some env variables require specific values according to your platform.
+
+### RH850/U2A16
+
+Follow the steps exactly in the order listed below:
+
+1. To build FreeRTOS, run:
+
+```shell
+export APP_SRC_DIR="$BAO_DEMOS/demos/freertos+baremetal/freertos-app"
+export RO_MEM_BASE=0x100000
+export RO_MEM_SIZE=0x100000
+export RW_MEM_BASE=0xfe100000
+export RW_MEM_SIZE=0x80000
+export SHMEM_BASE=0xfe480000
+export SHMEM_SIZE=0x1000
+```
+
+2. Follow the instructions in [FreeRTOS](../../guests/freertos/README.md).
+
+
+3. Then, to build the Baremetal app, run:
+
+```shell
+export APP_SRC_DIR="$BAO_DEMOS/demos/freertos+baremetal/baremetal-app"
+export RO_MEM_BASE=0x200000
+export RO_MEM_SIZE=0x100000
+export RW_MEM_BASE=0xfe400000
+export RW_MEM_SIZE=0x80000
+export SHMEM_BASE=0xfe480000
+export SHMEM_SIZE=0x1000
+export CPPFLAGS="\
+-DPLAT_UART_ADDR=0xFFD28400UL \
+-DUART_IRQ_ID=434UL \
+-DPLAT_OSTM_BASE=0xFFBF0100UL \
+-DTIMER_IRQ_ID=200UL"
+```
+
+4. Follow the instructions in [Baremetal](../../guests/baremetal/README.md).
+
+5. To avoid any conflict with further steps, unset the CPPFLAGS env variable
+```shell
+unset CPPFLAGS
+```

--- a/demos/freertos+baremetal/baremetal-app/main.c
+++ b/demos/freertos+baremetal/baremetal-app/main.c
@@ -1,0 +1,95 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <core.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <cpu.h>
+#include <wfi.h>
+#include <spinlock.h>
+#include <plat.h>
+#include <irq.h>
+#include <uart.h>
+#include <timer.h>
+#include <hypercall.h>
+
+#define TIMER_INTERVAL (TIME_S(1))
+
+#define shared_buff (*(volatile char *)0xfe480000UL)
+
+extern volatile unsigned int uart_rxcnt;
+
+spinlock_t print_lock = SPINLOCK_INITVAL;
+
+void uart_rx_handler()
+{
+    uart_rxcnt++;
+    
+    printf("cpu%d: %s\n", get_cpuid(), __func__);
+    
+    shared_buff = uart_getchar();
+
+    uart_clear_rxirq();
+    bao_hypercall(1UL, 0, 0);
+}
+
+void ipi_handler()
+{
+    irq_clear_ipi();
+    printf("cpu%d: %s\n", get_cpuid(), __func__);
+    irq_send_ipi(1ull << (get_cpuid() + 1));
+}
+
+void timer_handler()
+{
+    printf("cpu%d: %s\n", get_cpuid(), __func__);
+    timer_set(TIMER_INTERVAL);
+    irq_send_ipi(1ull << (get_cpuid() + 1));
+}
+
+void main(void)
+{
+    static volatile bool master_done = false;
+
+    if (cpu_is_master()) {
+
+        shared_buff = '\0';
+
+        spin_lock(&print_lock);
+        printf("Bao bare-metal test guest\n");
+        spin_unlock(&print_lock);
+
+        irq_set_handler(UART_IRQ_ID, uart_rx_handler);
+        irq_set_handler(TIMER_IRQ_ID, timer_handler);
+
+        uart_enable_rxirq();
+
+        timer_set(TIMER_INTERVAL);
+        irq_enable(TIMER_IRQ_ID);
+        irq_set_prio(TIMER_IRQ_ID, TIMER_IRQ_PRIO);
+
+        irq_enable(UART_IRQ_ID);
+        irq_set_prio(UART_IRQ_ID, UART_IRQ_PRIO);
+
+        timer_enable();
+
+        master_done = true;
+    }
+
+    irq_set_handler(IPI_IRQ_ID, ipi_handler);
+
+    irq_enable(IPI_IRQ_ID);
+    irq_set_prio(IPI_IRQ_ID, IPI_IRQ_PRIO);
+
+    while (!master_done)
+        ;
+    spin_lock(&print_lock);
+    printf("cpu %d up\n", get_cpuid());
+    spin_unlock(&print_lock);
+
+    while (1) {
+        wfi();
+    }
+}

--- a/demos/freertos+baremetal/baremetal-app/sources.mk
+++ b/demos/freertos+baremetal/baremetal-app/sources.mk
@@ -1,0 +1,1 @@
+src_c_srcs:= main.c

--- a/demos/freertos+baremetal/configs/rh850-u2a16.c
+++ b/demos/freertos+baremetal/configs/rh850-u2a16.c
@@ -1,0 +1,184 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <config.h>
+
+struct config config = {
+
+    CONFIG_HEADER
+
+    .shmemlist_size = 1,
+    .shmemlist = (struct shmem[]) {
+        // Cluster2 RAM
+        [0] = { 
+            .base = 0xfe480000,
+            .size = 0x1000
+        }
+    },
+
+    .vmlist_size = 2,
+
+    .vmlist = (struct vm_config[]){
+        // VM1: FreeRTOS
+        {
+            .entry = 0x100000,
+            .image = VM_IMAGE_LOADED(0x100000,0x100000,0x100000),
+            // .cpu_affinity = 0x1,
+
+            .platform = {
+                .cpu_num = 1,
+
+                .region_num = 2,
+                .regions =  (struct vm_mem_region[]) {
+                    // Code Flash (Bank B) - Code
+                    {
+                        .base = 0x100000,
+                        .size = 0x100000
+                    },
+                    // Cluster1 RAM - Data
+                    {
+                        .base = 0xfe100000,
+                        .size = 0x80000
+                    }
+                },
+
+                .ipc_num = 1,
+                .ipcs = (struct ipc[]) {
+                    {
+                        .base = 0xfe480000,
+                        .size = 0x1000,
+                        .shmem_id = 0,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) {32}
+                    }
+                },
+
+                .dev_num = 4,
+                .devs =  (struct vm_dev_region[]) {
+                    // Standby Controller
+                    {
+                        // 0xFF981000 -> 0xFF982000
+                        .id = 0,
+                        .pa = 0xFF981000,
+                        .va = 0xFF981000,
+                        .size = 0x1000,
+                        .interrupt_num = 0,
+                        .interrupts = NULL
+                    },
+                    // RLIN35
+                    {
+                        // 0xFFC7C100 -> 0xFFC7C140
+                        .id = 0,
+                        .pa = 0xFFC7C100,
+                        .va = 0xFFC7C100,
+                        .size = 0x40,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) {438}
+                    },
+                    // OSTM0
+                    {
+                        // 0xFFBF0000 -> 0xFFBF0100
+                        .id = 0,
+                        .pa = 0xFFBF0000,
+                        .va = 0xFFBF0000,
+                        .size = 0x100,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) {199}
+                    },
+                    // INTC1 (self)
+                    {
+                        // 0xFFFC0000 -> 0xFFFC4000
+                        .id = 0,
+                        .pa = 0xFFFC0000,
+                        .va = 0xFFFC0000,
+                        .size = 0x4000,
+                        .interrupt_num = 0,
+                        .interrupts = NULL
+                    }
+                },
+            }
+        },
+
+        // VM2: Baremetal
+        {
+            .entry = 0x200000,
+            .image = VM_IMAGE_LOADED(0x200000,0x200000,0x100000),
+            // .cpu_affinity = 0xE,
+
+            .platform = {
+                .cpu_num = 3,
+
+                .region_num = 2,
+                .regions =  (struct vm_mem_region[]) {
+                    // Code Flash (Bank B) - Code
+                    {
+                        .base = 0x200000,
+                        .size = 0x100000
+                    },
+                    // Cluster1 RAM - Data
+                    {
+                        .base = 0xfe400000,
+                        .size = 0x80000
+                    }
+                },
+
+                .ipc_num = 1,
+                .ipcs = (struct ipc[]) {
+                    {
+                        .base = 0xfe480000,
+                        .size = 0x1000,
+                        .shmem_id = 0,
+                        .interrupt_num = 0,
+                        .interrupts = NULL
+                    }
+                },
+
+                .dev_num = 4,
+                .devs =  (struct vm_dev_region[]) {
+                    // Standby Controller
+                    {
+                        // 0xFF981000 -> 0xFF982000
+                        .id = 0,
+                        .pa = 0xFF981000,
+                        .va = 0xFF981000,
+                        .size = 0x1000,
+                        .interrupt_num = 0,
+                        .interrupts = NULL
+                    },
+                    // RLIN34
+                    {
+                        // 0xFFD28400 -> 0xFFD28440
+                        .id = 0,
+                        .pa = 0xFFD28400,
+                        .va = 0xFFD28400,
+                        .size = 0x40,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) {434}
+                    },
+                    // OSTM1
+                    {
+                        // 0xFFBF0100 -> 0xFFBF0200
+                        .id = 0,
+                        .pa = 0xFFBF0100,
+                        .va = 0xFFBF0100,
+                        .size = 0x100,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) {200}
+                    },
+                    // INTC1 (self)
+                    {
+                        // 0xFFFC0000 -> 0xFFFC4000
+                        .id = 0,
+                        .pa = 0xFFFC0000,
+                        .va = 0xFFFC0000,
+                        .size = 0x4000,
+                        .interrupt_num = 0,
+                        .interrupts = NULL
+                    }
+                },
+            }
+        }
+    }
+};

--- a/demos/freertos+baremetal/freertos-app/main.c
+++ b/demos/freertos+baremetal/freertos-app/main.c
@@ -1,0 +1,229 @@
+/*
+ * FreeRTOS Kernel V10.2.1
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/* FreeRTOS kernel includes. */
+#include <FreeRTOS.h>
+#include <task.h>
+#include <stdio.h>
+
+#include <uart.h>
+#include <irq.h>
+#include <plat.h>
+
+// IRQ 32 is not used
+#define IPC_IRQ_ID  (32UL)
+
+#define shared_buff (*(volatile char *)0xfe480000UL)
+
+static unsigned long cnt = 0;
+
+/*
+ * Prototypes for the standard FreeRTOS callback/hook functions implemented
+ * within this file.  See https://www.freertos.org/a00016.html
+ */
+void vApplicationMallocFailedHook(void);
+void vApplicationIdleHook(void);
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName);
+void vApplicationTickHook(void);
+
+/*-----------------------------------------------------------*/
+
+void vTask(void *pvParameters)
+{
+    unsigned long counter = 0;
+    unsigned long id = (unsigned long)pvParameters;
+    while (1)
+    {
+        printf("Task%d: %d\n", id, counter++);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+}
+
+void uart_rx_handler(){
+    printf("%s\n", __func__);
+    uart_clear_rxirq();
+}
+
+void ipc_handler(){
+    
+    switch (shared_buff) {
+            
+    /* Increment */
+    case 'i':
+    case 'I':
+        cnt++;
+        break;
+
+    /* Decrement */
+    case 'd':
+    case 'D':
+        cnt--;
+        break;
+
+    /* Clear */
+    case 'c':
+    case 'C':
+        cnt = 0;
+        break;
+    
+    default:
+        printf("\"%c\" is not a valid option\n", shared_buff);
+        return;
+        break;
+    }
+
+    printf("Counter value: %d\n", cnt);
+}
+
+int main(void){
+
+    printf("Bao FreeRTOS guest\n");
+
+    uart_enable_rxirq();
+    irq_set_handler(UART_IRQ_ID, uart_rx_handler);
+    irq_set_prio(UART_IRQ_ID, IRQ_MAX_PRIO);
+    irq_enable(UART_IRQ_ID);
+
+    irq_set_handler(IPC_IRQ_ID, ipc_handler);
+    irq_set_prio(IPC_IRQ_ID, IRQ_MAX_PRIO);
+    irq_enable(IPC_IRQ_ID);
+
+    xTaskCreate(
+        vTask,
+        "Task1",
+        configMINIMAL_STACK_SIZE,
+        (void *)1,
+        tskIDLE_PRIORITY + 1,
+        NULL);
+
+    xTaskCreate(
+        vTask,
+        "Task2",
+        configMINIMAL_STACK_SIZE,
+        (void *)2,
+        tskIDLE_PRIORITY + 1,
+        NULL);
+
+    vTaskStartScheduler();
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationMallocFailedHook(void)
+{
+    /* vApplicationMallocFailedHook() will only be called if
+	configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
+	function that will get called if a call to pvPortMalloc() fails.
+	pvPortMalloc() is called internally by the kernel whenever a task, queue,
+	timer or semaphore is created.  It is also called by various parts of the
+	demo application.  If heap_1.c or heap_2.c are used, then the size of the
+	heap available to pvPortMalloc() is defined by configTOTAL_HEAP_SIZE in
+	FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
+	to query the size of free heap space that remains (although it does not
+	provide information on how the remaining heap might be fragmented). */
+    taskDISABLE_INTERRUPTS();
+    for (;;)
+        ;
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationIdleHook(void)
+{
+    /* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set
+	to 1 in FreeRTOSConfig.h.  It will be called on each iteration of the idle
+	task.  It is essential that code added to this hook function never attempts
+	to block in any way (for example, call xQueueReceive() with a block time
+	specified, or call vTaskDelay()).  If the application makes use of the
+	vTaskDelete() API function (as this demo application does) then it is also
+	important that vApplicationIdleHook() is permitted to return to its calling
+	function, because it is the responsibility of the idle task to clean up
+	memory allocated by the kernel to any task that has since been deleted. */
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
+{
+    (void)pcTaskName;
+    (void)pxTask;
+
+    /* Run time stack overflow checking is performed if
+	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
+	function is called if a stack overflow is detected. */
+    taskDISABLE_INTERRUPTS();
+    for (;;)
+        ;
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationTickHook(void)
+{
+}
+/*-----------------------------------------------------------*/
+
+void vAssertCalled(void)
+{
+    volatile uint32_t ulSetTo1ToExitFunction = 0;
+
+    taskDISABLE_INTERRUPTS();
+    while (ulSetTo1ToExitFunction != 1)
+    {
+        __asm volatile("NOP");
+    }
+}
+/*-----------------------------------------------------------*/
+
+/* This version of vApplicationAssert() is declared as a weak symbol to allow it
+to be overridden by a version implemented within the application that is using
+this BSP. */
+void vApplicationAssert( const char *pcFileName, uint32_t ulLine )
+{
+volatile uint32_t ul = 0;
+volatile const char *pcLocalFileName = pcFileName; /* To prevent pcFileName being optimized away. */
+volatile uint32_t ulLocalLine = ulLine; /* To prevent ulLine being optimized away. */
+
+	/* Prevent compile warnings about the following two variables being set but
+	not referenced.  They are intended for viewing in the debugger. */
+	( void ) pcLocalFileName;
+	( void ) ulLocalLine;
+
+	printf( "Assert failed in file %s, line %lu\r\n", pcLocalFileName, ulLocalLine );
+
+	/* If this function is entered then a call to configASSERT() failed in the
+	FreeRTOS code because of a fatal error.  The pcFileName and ulLine
+	parameters hold the file name and line number in that file of the assert
+	that failed.  Additionally, if using the debugger, the function call stack
+	can be viewed to find which line failed its configASSERT() test.  Finally,
+	the debugger can be used to set ul to a non-zero value, then step out of
+	this function to find where the assert function was entered. */
+	taskENTER_CRITICAL();
+	{
+		while( ul == 0 )
+		{
+			__asm volatile( "NOP" );
+		}
+	}
+	taskEXIT_CRITICAL();
+}

--- a/demos/freertos+baremetal/freertos-app/sources.mk
+++ b/demos/freertos+baremetal/freertos-app/sources.mk
@@ -1,0 +1,1 @@
+src_c_srcs:= main.c

--- a/demos/freertos+baremetal/make.mk
+++ b/demos/freertos+baremetal/make.mk
@@ -1,0 +1,31 @@
+include $(bao_demos)/guests/freertos/make.mk
+include $(bao_demos)/guests/baremetal/make.mk
+
+freertos_image:=$(wrkdir_demo_imgs)/freertos.bin
+freertos_args:=APP_SRC_DIR=$(bao_demos)/demos/freertos+baremetal/freertos-app
+
+ifeq ($(PLATFORM),rh850-u2a16)
+freertos_args+=RO_MEM_BASE=0x100000 RO_MEM_SIZE=0x100000 \
+				RW_MEM_BASE=0xfe100000 RW_MEM_SIZE=0x80000
+freertos_args+=SHMEM_BASE=0xfe480000 SHMEM_SIZE=0x1000
+endif
+
+$(eval $(call build-freertos, $(freertos_image), $(freertos_args)))
+
+baremetal_image:=$(wrkdir_demo_imgs)/baremetal.bin
+baremetal_args:=APP_SRC_DIR=$(bao_demos)/demos/freertos+baremetal/baremetal-app
+
+ifeq ($(PLATFORM),rh850-u2a16)
+baremetal_args+=RO_MEM_BASE=0x200000 RO_MEM_SIZE=0x100000 \
+				RW_MEM_BASE=0xfe400000 RW_MEM_SIZE=0x80000
+baremetal_args+=SHMEM_BASE=0xfe480000 SHMEM_SIZE=0x1000
+$(baremetal_image): export CPPFLAGS+=\
+    -DPLAT_UART_ADDR=0xFFD28400UL \
+    -DUART_IRQ_ID=434UL \
+    -DPLAT_OSTM_BASE=0xFFBF0100UL \
+    -DTIMER_IRQ_ID=200UL
+endif
+
+$(eval $(call build-baremetal, $(baremetal_image), $(baremetal_args)))
+
+guest_images:=$(freertos_image) $(baremetal_image)

--- a/guests/baremetal/README.md
+++ b/guests/baremetal/README.md
@@ -2,13 +2,13 @@
 
 Setup an environment variable for the baremetal app source code:
 
-```
+```shell
 export BAO_DEMOS_BAREMETAL=$BAO_DEMOS_WRKDIR_SRC/baremetal
 ```
 
 Clone and build the bao bare-metal guest application:
 
-```
+```shell
 git clone https://github.com/bao-project/bao-baremetal-guest.git \
     $BAO_DEMOS_BAREMETAL
 (cd $BAO_DEMOS_BAREMETAL && git checkout ec644fb2a915617f12d937f81245b429f01697f3)
@@ -17,6 +17,6 @@ make -C $BAO_DEMOS_BAREMETAL PLATFORM=$PLATFORM $BAREMETAL_PARAMS
 
 Copy the resulting binary to the final image's directory:
 
-```
+```shell
 cp $BAO_DEMOS_BAREMETAL/build/$PLATFORM/baremetal.bin $BAO_DEMOS_WRKDIR_IMGS
 ```

--- a/guests/freertos/README.md
+++ b/guests/freertos/README.md
@@ -2,21 +2,23 @@
 
 Setup an environment variable for the FreeRTOS repo:
 
-```
+```shell
 export BAO_DEMOS_FREERTOS=$BAO_DEMOS_WRKDIR_SRC/freertos
 ```
 
 Then clone and build the FreeRTOS:
 
-```
-git clone --recursive --shallow-submodules\
-    https://github.com/bao-project/freertos-over-bao.git\
-    $BAO_DEMOS_FREERTOS --branch demo-next
+```shell
+git clone https://github.com/bao-project/freertos-over-bao.git \
+    $BAO_DEMOS_FREERTOS
+(cd $BAO_DEMOS_FREERTOS && \
+git checkout cb9112f982c2768872536b811e013254d0184811 && \
+git submodule update --init --recursive)
 make -C $BAO_DEMOS_FREERTOS PLATFORM=$PLATFORM $FREERTOS_PARAMS
 ```
 
 Finally, copy the FreeRTOS image to the final guest image directory:
 
-```
+```shell
 cp $BAO_DEMOS_FREERTOS/build/$PLATFORM/freertos.bin $BAO_DEMOS_WRKDIR_IMGS
 ```

--- a/guests/freertos/make.mk
+++ b/guests/freertos/make.mk
@@ -1,10 +1,12 @@
 freertos_src:=$(wrkdir_src)/freertos
 freertos_repo:=https://github.com/bao-project/freertos-over-bao.git
-freertos_branch:=demo-next
+freertos_version:=cb9112f982c2768872536b811e013254d0184811
 
 $(freertos_src):
-	git clone --recursive --shallow-submodules --branch $(freertos_branch) \
-		$(freertos_repo) $(freertos_src)
+	git clone $(freertos_repo) $@
+	cd $@ && \
+		git checkout $(freertos_version) && \
+		git submodule update --init --recursive
 
 freertos_bin:=$(freertos_src)/build/$(PLATFORM)/freertos.bin
 

--- a/platforms/rh850-u2a16/README.md
+++ b/platforms/rh850-u2a16/README.md
@@ -34,3 +34,4 @@ make
 You must use the `rfp-cli` tool to program the `bao.bin` and guest images.
 Please take a look at the corresponding demo instructions for this platform.
 * [baremetal](baremetal.md)
+* [FreeRTOS+baremetal](freertos+baremetal.md)

--- a/platforms/rh850-u2a16/baremetal.md
+++ b/platforms/rh850-u2a16/baremetal.md
@@ -1,4 +1,4 @@
-# RH850-U2A16 berametal DEMO
+# RH850-U2A16 baremetal DEMO
 After building the demo follow these steps.
 
 <!--- instruction#1 -->

--- a/platforms/rh850-u2a16/freertos+baremetal.md
+++ b/platforms/rh850-u2a16/freertos+baremetal.md
@@ -1,0 +1,52 @@
+# RH850-U2A16 FreeRTOS+Baremetal DEMO
+After building the Bao and the guests, follow these steps.
+
+<!--- instruction#1 -->
+If you used the `A) Use automated make` option to build the demo images, first export the following variables:
+
+```shell
+export BAO_DEMOS=$(realpath .)
+export BAO_DEMOS_WRKDIR=$BAO_DEMOS/wrkdir
+export BAO_DEMOS_WRKDIR_SRC=$BAO_DEMOS_WRKDIR/srcs
+export BAO_DEMOS_WRKDIR_PLAT=$BAO_DEMOS_WRKDIR/imgs/$PLATFORM
+export BAO_DEMOS_WRKDIR_IMGS=$BAO_DEMOS_WRKDIR_PLAT/$DEMO
+```
+
+<!--- instruction#2 -->
+## Generate HEX files
+
+```shell
+${CROSS_COMPILE}objcopy -O ihex ${BAO_DEMOS_WRKDIR_SRC}/freertos/build/${PLATFORM}/freertos.elf ${BAO_DEMOS_WRKDIR_IMGS}/freertos.hex
+${CROSS_COMPILE}objcopy -O ihex ${BAO_DEMOS_WRKDIR_SRC}/baremetal/build/${PLATFORM}/baremetal.elf ${BAO_DEMOS_WRKDIR_IMGS}/baremetal.hex
+```
+
+## Connect the uart
+Connect to the UARTs assigned to the guests (baud 500000). For example:
+
+```shell
+screen /dev/ttyACM0 500000
+screen /dev/ttyUSB0 500000
+```
+
+> :information_source: By default, FreeRTOS uses RLIN35 as its UART, while the Baremetal app uses RLIN34. RH850-based boards may expose only one UART through the onboard USB interface. In such cases, a separate UART-to-USB adapter must be connected to the second UART pins (TX/RX). In the board we use, RLIN35 is connected to the onboard USB interface and RLIN34 is exposed through the P6_12 (TX) and P6_15 (RX) pins.
+
+<!--- instruction#3 -->
+## Flash the guest and bao binaries
+
+```shell
+rfp-cli -device RH850/U2x -tool e2 \
+    -osc 40.0 \
+    -auth id FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF \
+    -program -file $BAO_DEMOS_WRKDIR_IMGS/freertos.hex
+
+rfp-cli -device RH850/U2x -tool e2 \
+    -osc 40.0 \
+    -auth id FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF \
+    -program -file $BAO_DEMOS_WRKDIR_IMGS/baremetal.hex
+
+rfp-cli -device RH850/U2x -tool e2 \
+    -osc 40.0 \
+    -auth id FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF \
+    -program -bin 0x0 $BAO_DEMOS_WRKDIR_IMGS/bao.bin -run
+```
+<!--- instruction#end -->


### PR DESCRIPTION
This PR adds a new FreeRTOS+Baremetal demo model, featuring support for the RH850/U2A16 platform.

The demo runs FreeRTOS (single-core) and a Baremetal app (3 cores) simultaneously on top of Bao. Both guests can communicate between each other via a shared memory object which includes a shared memory region and a notification mechanism in the form of a hardware interrupt.

For more information about the demo, see the detailed description [here](https://github.com/bao-project/bao-demos/blob/feat/rh850-freertos-bm/demos/freertos+baremetal/README.md).

:warning: Depends on https://github.com/bao-project/freertos-over-bao/pull/10