### PR TITLE
Update Bao version used in demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Clone Bao's repo to the working directory:
 ```
 export BAO_DEMOS_BAO=$BAO_DEMOS_WRKDIR_SRC/bao
 git clone https://github.com/bao-project/bao-hypervisor $BAO_DEMOS_BAO\
-    --branch demo-next
+    --branch v2.0.0
 ```
 
 Copy your config to the working directory:


### PR DESCRIPTION
The current automake build flow pins the Bao version to the v2.0 release of the Bao hypervisor.

This PR updates the build flow to use the `demo-next` branch instead, allowing the demos to build against the latest Bao changes and features.