### PR TITLE
fix(qemu-riscv32): fix QEMU and OpenSBI references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ environment+=BAO_DEMOS_SDCARD=/media/$$USER/boot
 all: platform
 
 bao_repo:=https://github.com/bao-project/bao-hypervisor
-bao_version:=2956f48f8a56a147303521315b34325014affbcd
+bao_version:=997ba1dd811f6728ee2694f7876907b5528ded6c
 bao_src:=$(wrkdir_src)/bao
 bao_cfg_repo:=$(wrkdir_demo_imgs)/config
 wrkdirs+=$(bao_cfg_repo)

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Clone Bao's repo to the working directory:
 ```
 export BAO_DEMOS_BAO=$BAO_DEMOS_WRKDIR_SRC/bao
 git clone https://github.com/bao-project/bao-hypervisor $BAO_DEMOS_BAO
-(cd $BAO_DEMOS_BAO && git checkout 2956f48f8a56a147303521315b34325014affbcd)
+(cd $BAO_DEMOS_BAO && git checkout 997ba1dd811f6728ee2694f7876907b5528ded6c)
 ```
 
 Copy your config to the working directory:
@@ -258,7 +258,8 @@ Build the firmware and deploy the system according to the target platform:
 * [Semidrive E3650](platforms/e3650/README.md)
 
 #### RISC-V platforms:
-* [QEMU virt](platforms/qemu-riscv64-virt/README.md)
+* [QEMU 32 virt](platforms/qemu-riscv32-virt/README.md)
+* [QEMU 64 virt](platforms/qemu-riscv64-virt/README.md)
 * [SpacemiT K3 CoM260 Kit](platforms/k3-com260/README.md)
 
 #### RH850 platforms:

--- a/platforms/qemu-riscv32-virt/README.md
+++ b/platforms/qemu-riscv32-virt/README.md
@@ -1,1 +1,87 @@
-../qemu-riscv64-virt/README.md
+# Qemu RV32 virt
+
+## 1) Download build and install RV64 qemu
+
+---
+
+**NOTE**
+
+If you already have qemu-system-riscv32 installed or you don't want to compile 
+it but install it directly using a package manager or some other method, please
+make sure you are using version 7.2.0 or higher. If so, you can skip this step.
+
+---
+
+```
+export BAO_DEMOS_QEMU=$BAO_DEMOS_WRKDIR_SRC/qemu-$ARCH
+git clone https://github.com/qemu/qemu.git $BAO_DEMOS_QEMU --depth 1\
+   --branch v11.1.0-rc0
+cd $BAO_DEMOS_QEMU
+./configure --target-list=riscv32-softmmu --enable-slirp
+make -j$(nproc)
+sudo make install
+```
+
+## 2) Compile OpenSBI
+
+```
+export BAO_DEMOS_OPENSBI=$BAO_DEMOS_WRKDIR_SRC/opensbi
+git clone https://github.com/bao-project/opensbi.git $BAO_DEMOS_OPENSBI\
+    --depth 1 --branch bao/demo-next
+make -C $BAO_DEMOS_OPENSBI PLATFORM=generic \
+    CROSS_COMPILE=$OPENSBI_CROSS_COMPILE \
+    PLATFORM_RISCV_XLEN=32 \
+    FW_PAYLOAD=y \
+    FW_PAYLOAD_FDT_ADDR=0x80100000\
+    FW_PAYLOAD_PATH=$BAO_DEMOS_WRKDIR_IMGS/bao.bin
+cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.bin\
+    $BAO_DEMOS_WRKDIR_IMGS/opensbi.bin
+```
+
+## 3) Run QEMU
+
+```
+ qemu-system-riscv32 -nographic\
+    -M virt -cpu rv32,priv_spec=v1.13.0,sstc=true -m 4G -smp 4\
+    -bios $BAO_DEMOS_WRKDIR_IMGS/opensbi.bin\
+    -device virtio-net-device,netdev=net0 \
+    -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\
+    -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3 -S
+```
+
+<!--- instruction#1 -->
+## 4) Setup connections and jump to Bao
+
+Qemu will let you know in which pseudo-terminals it placed the virtio serial.
+For example:
+
+```
+char device redirected to /dev/pts/4 (label serial3)
+```
+
+Open a new terminal and connect to it. For example:
+
+```
+screen /dev/pts/4
+```
+
+Finally, start the emulation by pressing `Ctrl-a` then `c` in the terminal you 
+launched qemu to access the monitor console and running:
+
+```
+(qemu) cont
+```
+
+Then, press `Ctrl-a` and `c` again to be able to interact with the guest 
+through the serial console.
+
+If you are running a Linux guest you can also connect via ssh to it by opening 
+a new terminal and running:
+
+```
+ssh root@localhost -p 5555
+```
+
+When you want to leave QEMU press `Ctrl-a` then `x`.
+ 
+<!--- instruction#end -->

--- a/platforms/qemu-riscv64-virt/README.md
+++ b/platforms/qemu-riscv64-virt/README.md
@@ -29,6 +29,8 @@ export BAO_DEMOS_OPENSBI=$BAO_DEMOS_WRKDIR_SRC/opensbi
 git clone https://github.com/bao-project/opensbi.git $BAO_DEMOS_OPENSBI\
     --depth 1 --branch bao/demo-next
 make -C $BAO_DEMOS_OPENSBI PLATFORM=generic \
+    CROSS_COMPILE=$OPENSBI_CROSS_COMPILE \
+    PLATFORM_RISCV_XLEN=64 \
     FW_PAYLOAD=y \
     FW_PAYLOAD_FDT_ADDR=0x80100000\
     FW_PAYLOAD_PATH=$BAO_DEMOS_WRKDIR_IMGS/bao.bin


### PR DESCRIPTION
## Summary

- Add a dedicated README for `qemu-riscv32-virt` instead of reusing the RV64 README symlink.
- Fix the RV32 QEMU commands to use `qemu-system-riscv32`, `riscv32-softmmu`, and `rv32`.
- Update the OpenSBI payload references to use `fw_payload.bin` / `opensbi.bin`.