### PR TITLE
Add baremetal and linux+freertos demos for Spacemit K3 Com260

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ environment+=BAO_DEMOS_SDCARD=/media/$$USER/boot
 all: platform
 
 bao_repo:=https://github.com/bao-project/bao-hypervisor
-bao_version:=v2.0.0
+bao_version:=demo-next
 bao_src:=$(wrkdir_src)/bao
 bao_cfg_repo:=$(wrkdir_demo_imgs)/config
 wrkdirs+=$(bao_cfg_repo)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ define print-instructions
 		sed '1d;$d' | head -n -1 |\
 		sed -r -e 's/(.*)\[(.*)\]\((http.*)\)(.*)/\1\2 (\3)\4/g' |\
 		sed -r -e 's/(.*)\[(.*)\]\((\.\/(\.\.\/)*)(.*)\)(.*)/\1\2 (\.\/\5)\6/g' |\
-		pandoc --to plain --wrap=preserve | $(environment) envsubst
+		pandoc --to plain --wrap=preserve |\
+		$(environment) envsubst '$(foreach v,$(environment),$$$(firstword $(subst =, ,$v)))'
 	-@if [ $(strip $3) = false ];\
 		then  printf "\n(Press return to continue)\r"; read -s dummy;\
 		else for i in {1..80}; do printf "-"; done ; printf "\n"; fi

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ newer/compatible versions of the tools and software listed in
 ```
 sudo apt install build-essential bison flex git libssl-dev ninja-build \
     u-boot-tools pandoc libslirp-dev pkg-config libglib2.0-dev libpixman-1-dev \
-    gettext-base curl xterm cmake python3-pip xilinx-bootgen file cpio
+    gettext-base curl xterm cmake python3-pip xilinx-bootgen file cpio \
+    device-tree-compiler gdisk e2fsprogs
 
 pip3 install pykwalify packaging pyelftools
 ```
@@ -253,6 +254,7 @@ Build the firmware and deploy the system according to the target platform:
 
 #### RISC-V platforms:
 * [QEMU virt](platforms/qemu-riscv64-virt/README.md)
+* [SpacemiT K3 CoM260 Kit](platforms/k3-com260/README.md)
 
 #### RH850 platforms:
 * [RH850 U2A16](platforms/rh850-u2a16/README.md)
@@ -279,6 +281,7 @@ Build the firmware and deploy the system according to the target platform:
 | NXP S32Z270         | s32z270           | aarch32 |
 | QEMU RV64 virt      | qemu-riscv64-virt | riscv64 |
 | QEMU RV32 virt      | qemu-riscv32-virt | riscv32 |
+| SpacemiT K3 CoM260  | k3-com260         | riscv64 |
 | RH850-U2A16         | rh850-u2a16       | rh850   |
 | Infineon TC4Dx COM  | tc4dx             | tricore |
 | E3650               | e3650             | aarch32 |
@@ -310,6 +313,7 @@ Build the firmware and deploy the system according to the target platform:
 | s32z270           | x         |                |              | x                |        |                    |
 | qemu-riscv64-virt | x         | x              |              |                  | x      |                    |
 | qemu-riscv32-virt | x         | x              |              |                  |        |                    |
+| k3-com260         | x         | x              |              |                  |        |                    |
 | rh850-u2a16       | x         |                |              |                  |        |                    |
 | tc4dx             | x         |                |              |                  |        |                    |
 | e3650             | x         |                |              |                  |        |                    |
@@ -330,6 +334,9 @@ Build the firmware and deploy the system according to the target platform:
 | dtc                     | 1.6.1   |
 | gcc                     | 11.4.0  |
 | mkimage                 | 2022.01 |
+| mkenvimage              | 2022.01 |
+| sgdisk                  | 1.0.8   |
+| mke2fs                  | 1.46.5  |
 | cmake                   | 3.22.1  |
 | ninja                   | 1.10.1  |
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Clone Bao's repo to the working directory:
 ```
 export BAO_DEMOS_BAO=$BAO_DEMOS_WRKDIR_SRC/bao
 git clone https://github.com/bao-project/bao-hypervisor $BAO_DEMOS_BAO\
-    --branch v2.0.0
+    --branch demo-next
 ```
 
 Copy your config to the working directory:

--- a/demos/baremetal/configs/k3-com260.c
+++ b/demos/baremetal/configs/k3-com260.c
@@ -1,0 +1,48 @@
+#include <config.h>
+
+VM_IMAGE(baremetal_image, XSTR(BAO_DEMOS_WRKDIR_IMGS/baremetal.bin))
+
+struct config config = {
+
+    .vmlist_size = 1,
+    .vmlist = (struct vm_config[]) {
+        {
+            .image = {
+                .base_addr = 0x102000000,
+                .load_addr = VM_IMAGE_OFFSET(baremetal_image),
+                .size = VM_IMAGE_SIZE(baremetal_image)
+            },
+
+            .entry = 0x102000000,
+
+            .platform = {
+                .cpu_num = 8,
+
+                .region_num = 1,
+                .regions = (struct vm_mem_region[]) {
+                    {
+                        .base = 0x102000000,
+                        .size = 0x4000000
+                    }
+                },
+
+                .dev_num = 1,
+                .devs = (struct vm_dev_region[]) {
+                    {
+                        /* K3 UART0 passthrough */
+                        .pa = 0xd4017000,
+                        .va = 0xd4017000,
+                        .size = 0x1000,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 42 }
+                    },
+                },
+
+                .arch = {
+                    .irqc.aia.aplic.base = 0xe0804000,
+                    .irqc.aia.imsic.base = 0xe0400000,
+                }
+            },
+        },
+    }
+};

--- a/demos/linux+freertos/configs/k3-com260.c
+++ b/demos/linux+freertos/configs/k3-com260.c
@@ -1,0 +1,146 @@
+#include <config.h>
+
+VM_IMAGE(linux_image, XSTR(BAO_DEMOS_WRKDIR_IMGS/linux.bin))
+VM_IMAGE(freertos_image, XSTR(BAO_DEMOS_WRKDIR_IMGS/freertos.bin))
+
+struct config config = {
+
+    .shmemlist_size = 1,
+    .shmemlist = (struct shmem[]) {
+        [0] = { .size = 0x00010000, },
+    },
+
+    .vmlist_size = 2,
+    .vmlist = (struct vm_config[]) {
+        /* --- Linux: ethernet only, headless (network access) -------------- */
+        {
+            .image = {
+                .base_addr = 0x180000000,
+                .load_addr = VM_IMAGE_OFFSET(linux_image),
+                .size = VM_IMAGE_SIZE(linux_image),
+            },
+            .entry = 0x180000000,
+            .cpu_affinity = 0x7, /* harts 0-2 */
+
+            .platform = {
+                .cpu_num = 3,
+
+                .region_num = 1,
+                .regions = (struct vm_mem_region[]) {
+                    {
+                        .base = 0x180000000,
+                        .size = 0x40000000, /* 1 GiB */
+                        .place_phys = true,
+                        .phys = 0x180000000,
+                    },
+                },
+
+                .ipc_num = 1,
+                .ipcs = (struct ipc[]) {
+                    {
+                        .base = 0xf0000000,
+                        .size = 0x00010000,
+                        .shmem_id = 0,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 52 },
+                    },
+                },
+
+                .dev_num = 5,
+                .devs = (struct vm_dev_region[]) {
+                    {
+                        /* eth1 (gmac) + the wake irq */
+                        .pa = 0xcac82000,
+                        .va = 0xcac82000,
+                        .size = 0x2000,
+                        .interrupt_num = 2,
+                        .interrupts = (irqid_t[]) { 133, 277 },
+                    },
+                    {
+                        /* syscon_apbc (clock/reset provider for gpio + pinctrl) */
+                        .pa = 0xd4015000,
+                        .va = 0xd4015000,
+                        .size = 0x1000,
+                    },
+                    {
+                        /* syscon_apmu (gmac clocks + reset); reg base page-aligned */
+                        .pa = 0xd4282000,
+                        .va = 0xd4282000,
+                        .size = 0x1000,
+                    },
+                    {
+                        /* pinctrl (muxes the gmac1 RGMII/MDIO pads) */
+                        .pa = 0xd401e000,
+                        .va = 0xd401e000,
+                        .size = 0x1000,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 60 },
+                    },
+                    {
+                        /* gpio (gmac PHY reset line) + its syscon views */
+                        .pa = 0xd4019000,
+                        .va = 0xd4019000,
+                        .size = 0x1000,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 58 },
+                    }
+                },
+
+                .arch = {
+                    .irqc.aia.aplic.base = 0xe0804000,
+                    .irqc.aia.imsic.base = 0xe0400000,
+                },
+            },
+        },
+        /* --- FreeRTOS: owns the single UART console ----------------------- */
+        {
+            .image = {
+                /* built with STD_ADDR_SPACE: linked at and entered from 0x0 */
+                .base_addr = 0x0,
+                .load_addr = VM_IMAGE_OFFSET(freertos_image),
+                .size = VM_IMAGE_SIZE(freertos_image),
+            },
+            .entry = 0x0,
+            .cpu_affinity = 0x8, /* hart 3 */
+
+            .platform = {
+                .cpu_num = 1,
+
+                .region_num = 1,
+                .regions = (struct vm_mem_region[]) {
+                    {
+                        .base = 0x0,
+                        .size = 0x8000000, /* 128 MiB */
+                    },
+                },
+
+                .ipc_num = 1,
+                .ipcs = (struct ipc[]) {
+                    {
+                        .base = 0xf0000000,
+                        .size = 0x00010000,
+                        .shmem_id = 0,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 52 },
+                    },
+                },
+
+                .dev_num = 1,
+                .devs = (struct vm_dev_region[]) {
+                    {
+                        .pa = 0xd4017000, 
+                        .va = 0xd4017000, 
+                        .size = 0x1000,
+                        .interrupt_num = 1,
+                        .interrupts = (irqid_t[]) { 42 },
+                    },
+                },
+
+                .arch = {
+                    .irqc.aia.aplic.base = 0xe0804000,
+                    .irqc.aia.imsic.base = 0xe0400000,
+                },
+            },
+        },
+    },
+};

--- a/demos/linux+freertos/devicetrees/k3-com260/linux.dts
+++ b/demos/linux+freertos/devicetrees/k3-com260/linux.dts
@@ -1,0 +1,519 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+	model = "SpacemiT K3";
+	compatible = "spacemit,k3";
+
+	cpus: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <24000000>;
+
+		cpu_0: cpu@0 {
+			compatible = "spacemit,x100", "riscv";
+			device_type = "cpu";
+			reg = <0>;
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "b", "v", "h",
+					       "sha", "shcounterenw", "shgatpa", "shtvala",
+					       "shvsatpa", "shvstvala", "shvstvecd", "smaia",
+					       "smstateen", "ssaia", "ssccptr", "sscofpmf",
+					       "sscounterenw", "ssnpm", "ssstateen", "sstc",
+					       "sstvala", "sstvecd", "ssu64xl", "svade",
+					       "svinval", "svnapot", "svpbmt", "za64rs",
+					       "zawrs", "zba", "zbb", "zbc", "zbs", "zca",
+					       "zcb", "zcd", "zcmop", "zfa", "zfbfmin",
+					       "zfh", "zfhmin", "zicbom", "zicbop", "zicboz",
+					       "ziccamoa", "ziccif", "zicclsm", "zicntr",
+					       "zicond", "zicsr", "zifencei", "zihintntl",
+					       "zihintpause", "zihpm", "zimop", "zkt", "zvbb",
+					       "zvbc", "zvfbfmin", "zvfbfwma", "zvfh",
+					       "zvfhmin", "zvkb", "zvkg", "zvkn", "zvknc",
+					       "zvkned", "zvkng", "zvknha", "zvknhb", "zvks",
+					       "zvksc", "zvksed", "zvksg", "zvksh", "zvkt";
+			riscv,cbom-block-size = <64>;
+			riscv,cbop-block-size = <64>;
+			riscv,cboz-block-size = <64>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <256>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <256>;
+			next-level-cache = <&l2_cache0>;
+			mmu-type = "riscv,sv39";
+
+			cpu0_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		cpu_1: cpu@1 {
+			compatible = "spacemit,x100", "riscv";
+			device_type = "cpu";
+			reg = <1>;
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "b", "v", "h",
+					       "sha", "shcounterenw", "shgatpa", "shtvala",
+					       "shvsatpa", "shvstvala", "shvstvecd", "smaia",
+					       "smstateen", "ssaia", "ssccptr", "sscofpmf",
+					       "sscounterenw", "ssnpm", "ssstateen", "sstc",
+					       "sstvala", "sstvecd", "ssu64xl", "svade",
+					       "svinval", "svnapot", "svpbmt", "za64rs",
+					       "zawrs", "zba", "zbb", "zbc", "zbs", "zca",
+					       "zcb", "zcd", "zcmop", "zfa", "zfbfmin",
+					       "zfh", "zfhmin", "zicbom", "zicbop", "zicboz",
+					       "ziccamoa", "ziccif", "zicclsm", "zicntr",
+					       "zicond", "zicsr", "zifencei", "zihintntl",
+					       "zihintpause", "zihpm", "zimop", "zkt", "zvbb",
+					       "zvbc", "zvfbfmin", "zvfbfwma", "zvfh",
+					       "zvfhmin", "zvkb", "zvkg", "zvkn", "zvknc",
+					       "zvkned", "zvkng", "zvknha", "zvknhb", "zvks",
+					       "zvksc", "zvksed", "zvksg", "zvksh", "zvkt";
+			riscv,cbom-block-size = <64>;
+			riscv,cbop-block-size = <64>;
+			riscv,cboz-block-size = <64>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <256>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <256>;
+			next-level-cache = <&l2_cache0>;
+			mmu-type = "riscv,sv39";
+
+			cpu1_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		cpu_2: cpu@2 {
+			compatible = "spacemit,x100", "riscv";
+			device_type = "cpu";
+			reg = <2>;
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "b", "v", "h",
+					       "sha", "shcounterenw", "shgatpa", "shtvala",
+					       "shvsatpa", "shvstvala", "shvstvecd", "smaia",
+					       "smstateen", "ssaia", "ssccptr", "sscofpmf",
+					       "sscounterenw", "ssnpm", "ssstateen", "sstc",
+					       "sstvala", "sstvecd", "ssu64xl", "svade",
+					       "svinval", "svnapot", "svpbmt", "za64rs",
+					       "zawrs", "zba", "zbb", "zbc", "zbs", "zca",
+					       "zcb", "zcd", "zcmop", "zfa", "zfbfmin",
+					       "zfh", "zfhmin", "zicbom", "zicbop", "zicboz",
+					       "ziccamoa", "ziccif", "zicclsm", "zicntr",
+					       "zicond", "zicsr", "zifencei", "zihintntl",
+					       "zihintpause", "zihpm", "zimop", "zkt", "zvbb",
+					       "zvbc", "zvfbfmin", "zvfbfwma", "zvfh",
+					       "zvfhmin", "zvkb", "zvkg", "zvkn", "zvknc",
+					       "zvkned", "zvkng", "zvknha", "zvknhb", "zvks",
+					       "zvksc", "zvksed", "zvksg", "zvksh", "zvkt";
+			riscv,cbom-block-size = <64>;
+			riscv,cbop-block-size = <64>;
+			riscv,cboz-block-size = <64>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <256>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <256>;
+			next-level-cache = <&l2_cache0>;
+			mmu-type = "riscv,sv39";
+
+			cpu2_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		cpu_3: cpu@3 {
+			compatible = "spacemit,x100", "riscv";
+			device_type = "cpu";
+			reg = <3>;
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "b", "v", "h",
+					       "sha", "shcounterenw", "shgatpa", "shtvala",
+					       "shvsatpa", "shvstvala", "shvstvecd", "smaia",
+					       "smstateen", "ssaia", "ssccptr", "sscofpmf",
+					       "sscounterenw", "ssnpm", "ssstateen", "sstc",
+					       "sstvala", "sstvecd", "ssu64xl", "svade",
+					       "svinval", "svnapot", "svpbmt", "za64rs",
+					       "zawrs", "zba", "zbb", "zbc", "zbs", "zca",
+					       "zcb", "zcd", "zcmop", "zfa", "zfbfmin",
+					       "zfh", "zfhmin", "zicbom", "zicbop", "zicboz",
+					       "ziccamoa", "ziccif", "zicclsm", "zicntr",
+					       "zicond", "zicsr", "zifencei", "zihintntl",
+					       "zihintpause", "zihpm", "zimop", "zkt", "zvbb",
+					       "zvbc", "zvfbfmin", "zvfbfwma", "zvfh",
+					       "zvfhmin", "zvkb", "zvkg", "zvkn", "zvknc",
+					       "zvkned", "zvkng", "zvknha", "zvknhb", "zvks",
+					       "zvksc", "zvksed", "zvksg", "zvksh", "zvkt";
+			riscv,cbom-block-size = <64>;
+			riscv,cbop-block-size = <64>;
+			riscv,cboz-block-size = <64>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <256>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <256>;
+			next-level-cache = <&l2_cache0>;
+			mmu-type = "riscv,sv39";
+
+			cpu3_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		l2_cache0: cache-controller-0 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <4194304>;
+			cache-sets = <4096>;
+			cache-unified;
+		};
+
+		l2_cache1: cache-controller-1 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <4194304>;
+			cache-sets = <4096>;
+			cache-unified;
+		};
+
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&cpu_0>;
+				};
+				core1 {
+					cpu = <&cpu_1>;
+				};
+				core2 {
+					cpu = <&cpu_2>;
+				};
+				core3 {
+					cpu = <&cpu_3>;
+				};
+			};
+		};
+	};
+
+	memory@180000000 {
+		device_type = "memory";
+		reg = <0x1 0x80000000 0x0 0x40000000>;
+	};
+
+	clocks {
+		vctcxo_1m: clock-1m {
+			compatible = "fixed-clock";
+			clock-frequency = <1000000>;
+			clock-output-names = "vctcxo_1m";
+			#clock-cells = <0>;
+		};
+
+		vctcxo_24m: clock-24m {
+			compatible = "fixed-clock";
+			clock-frequency = <24000000>;
+			clock-output-names = "vctcxo_24m";
+			#clock-cells = <0>;
+		};
+
+		vctcxo_3m: clock-3m {
+			compatible = "fixed-clock";
+			clock-frequency = <3000000>;
+			clock-output-names = "vctcxo_3m";
+			#clock-cells = <0>;
+		};
+
+		osc_32k: clock-32k {
+			compatible = "fixed-clock";
+			clock-frequency = <32000>;
+			clock-output-names = "osc_32k";
+			#clock-cells = <0>;
+		};
+	};
+
+	soc: soc {
+		compatible = "simple-bus";
+		interrupt-parent = <&saplic>;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		dma-noncoherent;
+		ranges;
+
+		syscon_apmu: system-controller@d4282800 {
+			compatible = "spacemit,k3-syscon-apmu";
+			reg = <0x0 0xd4282800 0x0 0x400>;
+			clocks = <&osc_32k>, <&vctcxo_1m>, <&vctcxo_3m>, <&vctcxo_24m>;
+			clock-names = "osc", "vctcxo_1m", "vctcxo_3m", "vctcxo_24m";
+			#clock-cells = <1>;
+			#power-domain-cells = <1>;
+			#reset-cells = <1>;
+		};
+
+		/* APBC clock/reset controller: clock provider for the GPIO and pinctrl
+		 * blocks, which gmac1 depends on (pinctrl-0 + PHY reset-gpio). Needs its
+		 * MMIO (0xd4015000) passed through to the Bao guest. */
+		syscon_apbc: system-controller@d4015000 {
+			compatible = "spacemit,k3-syscon-apbc";
+			reg = <0x0 0xd4015000 0x0 0x1000>;
+			clocks = <&osc_32k>, <&vctcxo_1m>, <&vctcxo_3m>, <&vctcxo_24m>;
+			clock-names = "osc", "vctcxo_1m", "vctcxo_3m", "vctcxo_24m";
+			#clock-cells = <1>;
+			#reset-cells = <1>;
+		};
+
+		/* GPIO register block, also viewed as two syscon regions (overlapping
+		 * the same 0xd4019000 page). Needs 0xd4019000 (0x1000) passed through. */
+		syscon_gpio: syscon-gpio {
+			compatible = "syscon";
+			reg = <0x0 0xd4019000 0x0 0x800>;
+		};
+
+		syscon_gpio_edge: syscon-gpio-edge {
+			compatible = "syscon";
+			reg = <0x0 0xd4019800 0x0 0x10>;
+		};
+
+		/* GPIO controller - provides the PHY reset line (gmac1 bank1/line5). */
+		gpio: gpio@d4019000 {
+			compatible = "spacemit,k3-gpio";
+			reg = <0x0 0xd4019000 0x0 0x100>;
+			clocks = <&syscon_apbc 20>, <&syscon_apbc 21>; /* CLK_APBC_GPIO[_BUS] */
+			clock-names = "core", "bus";
+			gpio-controller;
+			#gpio-cells = <3>;
+			interrupts = <58 4>;
+			interrupt-parent = <&saplic>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			syscon-gpio-regs = <&syscon_gpio>;
+			syscon-gpio-edge = <&syscon_gpio_edge>;
+			gpio-ranges = <&pinctrl 0 0 0 32>,
+				      <&pinctrl 1 0 32 32>,
+				      <&pinctrl 2 0 64 32>,
+				      <&pinctrl 3 0 96 32>;
+		};
+
+		/* Pinctrl controller - muxes the gmac1 RGMII/MDIO pads (gmac1_cfg).
+		 * Needs 0xd401e000 (0x1000) passed through. */
+		pinctrl: pinctrl@d401e000 {
+			compatible = "spacemit,k3-pinctrl";
+			reg = <0x0 0xd401e000 0x0 0x400>,
+			      <0x0 0xd401e800 0x0 0x34>;
+			clocks = <&syscon_apbc 103>, <&syscon_apbc 104>; /* CLK_APBC_AIB[_BUS] */
+			clock-names = "func", "bus";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <60 4>;
+			interrupt-parent = <&saplic>;
+			spacemit,gpio-edge = <&syscon_gpio_edge>;
+			spacemit,apbc = <&syscon_apbc 0x50>;
+			spacemit,apmu = <&syscon_apmu>;
+		};
+
+		eth1: ethernet@cac82000 {
+			compatible = "spacemit,k3-gmac", "snps,dwmac-5.10a";
+			reg = <0x0 0xcac82000 0x0 0x2000>;
+			clocks = <&syscon_apmu 79>,
+				 <&syscon_apmu 81>;
+			clock-names = "stmmaceth", "ptp_ref";
+			interrupts = <133 4>,
+				     <277 4>;
+			interrupt-names = "macirq", "eth_wake_irq";
+			resets = <&syscon_apmu 78>;
+			reset-names = "stmmaceth";
+			rx-fifo-depth = <8192>;
+			tx-fifo-depth = <8192>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <32>;
+			snps,aal;
+			snps,tso;
+			snps,txpbl = <8>;
+			snps,rxpbl = <8>;
+			snps,force_sf_dma_mode;
+			snps,axi-config = <&gmac1_axi_setup>;
+			/* dwmac-spacemit-ethqos reads these as 3 separate properties:
+			 * spacemit,apmu = phandle only; ctrl/dline offsets as u32. */
+			spacemit,apmu = <&syscon_apmu>;
+			spacemit,ctrl-offset = <0x3ec>;
+			spacemit,dline-offset = <0x3f0>;
+			status = "disabled";
+
+			mdio {
+				compatible = "snps,dwmac-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+
+			gmac1_axi_setup: stmmac-axi-config {
+				snps,wr_osr_lmt = <0xf>;
+				snps,rd_osr_lmt = <0xf>;
+				/* max axi burst len is 256 */
+				snps,blen = <256 128 64 32 16 0 0>;
+			};
+		};
+
+		simsic: interrupt-controller@e0400000 {
+			compatible = "spacemit,k3-imsics", "riscv,imsics";
+			/* Bao maps one S-level interrupt file per vCPU CONTIGUOUSLY, one
+			 * 4K page apart (vimsic: imsic.base + 4K * vcpu_id). The virtual
+			 * geometry is therefore guest-index-bits = 0 (absent) and
+			 * hart-index-bits = 2 (covers the 4 harts => 0x4000 window), so
+			 * cpu N's file sits at 0xe0400000 + N*0x1000. hart-index-bits
+			 * MUST match: the APLIC MSI driver decomposes the per-CPU MSI
+			 * address with it (WARN at aplic_msi_write_msg otherwise). Each
+			 * file is backed by a VS interrupt file: only 63 MSI ids. */
+			reg = <0x0 0xe0400000 0x0 0x4000>;
+			#interrupt-cells = <0>;
+			#msi-cells = <0>;
+			interrupt-controller;
+			interrupts-extended = <&cpu0_intc 9>, <&cpu1_intc 9>,
+					      <&cpu2_intc 9>, <&cpu3_intc 9>;
+			msi-controller;
+			riscv,hart-index-bits = <2>;
+			riscv,num-ids = <63>;
+		};
+
+		saplic: interrupt-controller@e0804000 {
+			compatible = "spacemit,k3-aplic", "riscv,aplic";
+			reg = <0x0 0xe0804000 0x0 0x4000>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			msi-parent = <&simsic>;
+			riscv,num-sources = <512>;
+		};
+	};
+
+	chosen {
+		bootargs = "clk_ignore_unused ip=192.168.42.15 carrier_timeout=0";
+	};
+
+    aliases {
+		ethernet0 = &eth1;
+	};
+
+	/* Bao inter-VM shared-memory channel to the FreeRTOS VM (shmem 0 in the
+	 * Bao config: base 0xf0000000, 64 KiB, notification irq 52). The channel
+	 * layout mirrors the FreeRTOS demo app: it writes its message at offset
+	 * 0x0 (our read-channel) and reads ours at 0x2000 (our write-channel).
+	 * Driver: the out-of-tree "ipc" module from bao-project/bao-linux-drivers
+	 * (compatible bao,ipcshmem); no kernel patch needed. */
+	bao-ipc@f0000000 {
+		compatible = "bao,ipcshmem";
+		reg = <0x0 0xf0000000 0x0 0x00010000>;
+		read-channel = <0x0 0x2000>;
+		write-channel = <0x2000 0x2000>;
+		interrupt-parent = <&saplic>;
+		interrupts = <52 1>; /* edge-rising: message irq injected by Bao */
+		id = <0>;
+	};
+};
+
+/* gmac1 RGMII + MDIO pad mux (effective CoM260-kit set: vendor groups 0/1/3/6,
+ * with kit's gmac1-2/4/5 deleted). pinmux raw form = (pin << 16) | func. */
+&pinctrl {
+	/omit-if-no-ref/
+	gmac1_cfg: gmac1-cfg {
+		gmac1_base_pins: gmac1-0-pins {
+			pinmux = <0x150001>,	/* pin 21 rx_ctl */
+				 <0x160001>,	/* pin 22 rx d0  */
+				 <0x170001>,	/* pin 23 rx d1  */
+				 <0x180001>,	/* pin 24 rxc    */
+				 <0x1b0001>,	/* pin 27 tx d0  */
+				 <0x1c0001>,	/* pin 28 tx d1  */
+				 <0x200001>,	/* pin 32 tx_ctl */
+				 <0x210001>,	/* pin 33 mdc    */
+				 <0x220001>;	/* pin 34 mdio   */
+			bias-disable;
+			drive-strength = <25>;
+			power-source = <1800>;
+		};
+		gmac1_rgmii_add_pins: gmac1-1-pins {
+			pinmux = <0x190001>,	/* pin 25 rx d2  */
+				 <0x1a0001>,	/* pin 26 rx d3  */
+				 <0x1d0001>,	/* pin 29 tx clk */
+				 <0x1e0001>,	/* pin 30 tx d2  */
+				 <0x1f0001>;	/* pin 31 tx d3  */
+			bias-disable;
+			drive-strength = <25>;
+			power-source = <1800>;
+		};
+		gmac1_int_pins: gmac1-3-pins {
+			pinmux = <0x230001>;	/* pin 35 phy int */
+			bias-disable;
+			drive-strength = <25>;
+			power-source = <1800>;
+		};
+		gmac1_pin6: gmac1-6-pins {
+			pinmux = <0x250000>;	/* pin 37 func 0 (board-specific) */
+			bias-disable;
+			drive-strength = <25>;
+			power-source = <1800>;
+		};
+	};
+};
+
+&eth1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&gmac1_cfg>;
+
+	max-speed = <1000>;
+	phy-mode = "rgmii";
+	phy-handle = <&gmac1_phy>;
+	snps,reset-gpios = <&gpio 1 5 1>;
+	snps,reset-delays-us = <0 20000 100000>;
+
+	spacemit,wake-irq-enable;
+
+	spacemit,clk-tuning-enable;
+	spacemit,clk-tuning-by-delayline;
+	spacemit,tx-phase = <47>;
+	spacemit,rx-phase = <53>;
+
+	status = "okay";
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "snps,dwmac-mdio";
+
+		gmac1_phy: ethernet-phy@1 {
+			compatible = "ethernet-phy-id001c.c916",
+				     "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@1 {
+					reg = <1>;
+					function = "lan";
+					color = <2>;
+					default-state = "keep";
+				};
+
+				led@2 {
+					reg = <2>;
+					function = "lan";
+					color = <6>;
+					default-state = "keep";
+				};
+			};
+		};
+	};
+};

--- a/guests/baremetal/README.md
+++ b/guests/baremetal/README.md
@@ -10,7 +10,7 @@ Clone and build the bao bare-metal guest application:
 
 ```
 git clone https://github.com/bao-project/bao-baremetal-guest.git\
-    --branch demo $BAO_DEMOS_BAREMETAL
+    --branch demo-next $BAO_DEMOS_BAREMETAL
 make -C $BAO_DEMOS_BAREMETAL PLATFORM=$PLATFORM $BAREMETAL_PARAMS
 ```
 

--- a/guests/baremetal/make.mk
+++ b/guests/baremetal/make.mk
@@ -1,6 +1,6 @@
 baremetal_src:=$(wrkdir_src)/baremetal
 baremetal_repo:=https://github.com/bao-project/bao-baremetal-guest.git
-baremetal_branch:=demo
+baremetal_branch:=demo-next
 
 $(baremetal_src):
 	git clone $(baremetal_repo) $@ --branch $(baremetal_branch)

--- a/guests/freertos/README.md
+++ b/guests/freertos/README.md
@@ -11,7 +11,7 @@ Then clone and build the FreeRTOS:
 ```
 git clone --recursive --shallow-submodules\
     https://github.com/bao-project/freertos-over-bao.git\
-    $BAO_DEMOS_FREERTOS --branch demo
+    $BAO_DEMOS_FREERTOS --branch demo-next
 make -C $BAO_DEMOS_FREERTOS PLATFORM=$PLATFORM $FREERTOS_PARAMS
 ```
 

--- a/guests/freertos/make.mk
+++ b/guests/freertos/make.mk
@@ -1,6 +1,6 @@
 freertos_src:=$(wrkdir_src)/freertos
 freertos_repo:=https://github.com/bao-project/freertos-over-bao.git
-freertos_branch:=demo
+freertos_branch:=demo-next
 
 $(freertos_src):
 	git clone --recursive --shallow-submodules --branch $(freertos_branch) \

--- a/guests/linux/buildroot/external/package/bao-drivers/bao-drivers.mk
+++ b/guests/linux/buildroot/external/package/bao-drivers/bao-drivers.mk
@@ -1,6 +1,8 @@
 BAO_DRIVERS_SITE = https://github.com/bao-project/bao-linux-drivers.git
 ifneq (,$(filter $(PLATFORM),s32g3))
 BAO_DRIVERS_VERSION = linux-v6.6
+else ifneq (,$(filter $(PLATFORM),k3-com260))
+BAO_DRIVERS_VERSION = linux-v6.18
 else
 BAO_DRIVERS_VERSION = linux-v6.15
 endif

--- a/guests/linux/configs/k3-com260.config
+++ b/guests/linux/configs/k3-com260.config
@@ -1,0 +1,55 @@
+# Linux kernel config fragment for the SpacemiT K3 (CoM260 Kit) Bao guest.
+# Merged on top of base.config + riscv64.config by the bao-demos linux build.
+#
+# Everything SpacemiT-specific gates on SOC_SPACEMIT; with it off none of the
+# per-SoC drivers below can be selected. The CCU (clock controller) is the one
+# that registers the apbc/apmu syscon regmaps the pinctrl/gpio/gmac drivers look
+# up - without it the serial/ethernet probes defer forever ("failed to get
+# syscon").
+
+# --- SoC platform gate ------------------------------------------------------
+CONFIG_ARCH_SPACEMIT=y
+CONFIG_SOC_SPACEMIT=y
+CONFIG_SOC_SPACEMIT_K3=y
+
+# --- RISC-V AIA: APLIC (MSI mode) + per-hart IMSIC (as emulated by Bao) ------
+CONFIG_RISCV_IMSIC=y
+CONFIG_RISCV_APLIC=y
+CONFIG_RISCV_APLIC_MSI=y
+
+# --- Clock controller (CCU): registers the apbc/apmu syscon regmaps ---------
+CONFIG_SPACEMIT_CCU=y
+CONFIG_SPACEMIT_K3_CCU=y
+
+# --- Pinctrl, GPIO, reset (gmac pads, PHY reset line, peripheral resets) -----
+CONFIG_PINCTRL_SPACEMIT_K1=y
+CONFIG_GPIO_SPACEMIT_K1=y
+CONFIG_RESET_SPACEMIT=y
+
+# --- Console: K3 UART0 is a 16550/xscale (8250) with 32-bit registers --------
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_SERIAL_OF_PLATFORM=y
+
+# --- Ethernet: Synopsys DWMAC core + SpacemiT K3 glue (eth1) -----------------
+CONFIG_NET=y
+CONFIG_INET=y
+CONFIG_NETDEVICES=y
+CONFIG_ETHERNET=y
+CONFIG_STMMAC_ETH=y
+CONFIG_STMMAC_PLATFORM=y
+CONFIG_DWMAC_SPACEMIT_ETHQOS=y
+
+# --- MDIO + PHY (board uses a RealTek RTL8211F RGMII PHY at MDIO address 1) ---
+CONFIG_PHYLIB=y
+CONFIG_MDIO_DEVICE=y
+CONFIG_MDIO_BUS=y
+CONFIG_FIXED_PHY=y
+CONFIG_REALTEK_PHY=y
+CONFIG_MOTORCOMM_PHY=y
+
+# --- Supporting subsystems (regmap/syscon, gpio, auxiliary bus) -------------
+CONFIG_MFD_SYSCON=y
+CONFIG_GPIOLIB=y
+CONFIG_OF_GPIO=y
+CONFIG_AUXILIARY_BUS=y

--- a/guests/linux/patches/k3-br-v1.0.y/0001-riscv-drop-spacemit-sbi-dcache-flush-calls.patch
+++ b/guests/linux/patches/k3-br-v1.0.y/0001-riscv-drop-spacemit-sbi-dcache-flush-calls.patch
@@ -1,0 +1,56 @@
+riscv: drop the SpacemiT vendor SBI dcache-flush calls
+
+The SpacemiT vendor kernel flushes the local dcache through a vendor SBI
+extension (sbi_flush_local_dcache_all) on cpu hotplug and suspend paths.
+As a Bao guest these ecalls land in the hypervisor's SBI handler, not in
+the vendor M-mode firmware, so they are useless under virtualization (and
+the mismatched config gating of the helper's definition can break the
+vmlinux link). Remove the call sites.
+
+diff --git a/arch/riscv/kernel/cpu-hotplug.c b/arch/riscv/kernel/cpu-hotplug.c
+index 2cf05d6d2..6bfad8e84 100644
+--- a/arch/riscv/kernel/cpu-hotplug.c
++++ b/arch/riscv/kernel/cpu-hotplug.c
+@@ -70,14 +70,8 @@ void __noreturn arch_cpu_idle_dead(void)
+ {
+ 	idle_task_exit();
+ 
+-#if defined(CONFIG_SOC_SPACEMIT)
+-	sbi_flush_local_dcache_all();
+-#endif
+ 	cpuhp_ap_report_dead();
+ 
+-#if defined(CONFIG_SOC_SPACEMIT)
+-	sbi_flush_local_dcache_all();
+-#endif
+ 	cpu_ops->cpu_stop();
+ 	/* It should never reach here */
+ 	BUG();
+diff --git a/arch/riscv/kernel/suspend.c b/arch/riscv/kernel/suspend.c
+index 79b41533c..575e6cc42 100644
+--- a/arch/riscv/kernel/suspend.c
++++ b/arch/riscv/kernel/suspend.c
+@@ -139,11 +139,6 @@ static int sbi_system_suspend(unsigned long sleep_type,
+ {
+ 	struct sbiret ret;
+ 
+-#if defined(CONFIG_SOC_SPACEMIT)
+-        /* flush the local cache */
+-        sbi_flush_local_dcache_all();
+-#endif
+-
+ 	ret = sbi_ecall(SBI_EXT_SUSP, SBI_EXT_SUSP_SYSTEM_SUSPEND,
+ 			sleep_type, resume_addr, opaque, 0, 0, 0);
+ 	if (ret.error)
+@@ -182,11 +177,6 @@ static int sbi_suspend_finisher(unsigned long suspend_type,
+ {
+ 	struct sbiret ret;
+ 
+-#if defined(CONFIG_SOC_SPACEMIT)
+-        /* flush the local cache */
+-        sbi_flush_local_dcache_all();
+-#endif
+-
+ 	ret = sbi_ecall(SBI_EXT_HSM, SBI_EXT_HSM_HART_SUSPEND,
+ 			suspend_type, resume_addr, opaque, 0, 0, 0);
+ 

--- a/platforms/k3-com260/README.md
+++ b/platforms/k3-com260/README.md
@@ -1,0 +1,174 @@
+# SpacemiT K3 - CoM260 Kit
+
+Bao on the SpacemiT K3 (octa-core X100, RISC-V, AIA + Sstc) on the CoM260 Kit
+(a.k.a. Banana Pi BPI-SM10). Boot chain: `BootROM -> FSBL -> OpenSBI -> U-Boot -> Bao`.
+
+> For the demos including Linux, Linux is NOT the generic kernel from the
+> demo guide: it is SpacemiT's vendor tree
+> (`https://github.com/spacemit-com/linux-6.18.git`, branch `k3-br-v1.0.y`).
+
+## 1) Compile OpenSBI
+
+The FSBL loads OpenSBI as the dynamic firmware, wrapped in SpacemiT's
+`fw_dynamic.itb` FIT, built from their OpenSBI tree:
+
+```
+export BAO_DEMOS_OPENSBI=$BAO_DEMOS_WRKDIR_SRC/opensbi
+git clone https://github.com/spacemit-com/opensbi.git $BAO_DEMOS_OPENSBI\
+    --depth 1 --branch k3-br-v1.0.0
+make -C $BAO_DEMOS_OPENSBI PLATFORM=generic PLATFORM_DEFCONFIG=k3_defconfig\
+    CROSS_COMPILE=$OPENSBI_CROSS_COMPILE
+cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_dynamic.itb\
+    $BAO_DEMOS_WRKDIR_PLAT
+```
+
+## 2) Compile U-Boot
+
+A single U-Boot build produces everything else the K3 boot flow needs:
+`u-boot.itb` (the main U-Boot FIT), `u-boot-env-default.bin` (the default
+environment image), `FSBL.bin` (the signed SPL the BootROM loads) and
+`bootinfo_block.bin` (the block that points the BootROM at the FSBL):
+
+```
+export BAO_DEMOS_UBOOT=$BAO_DEMOS_WRKDIR_SRC/u-boot-k3-br-v1.0.0
+git clone https://github.com/spacemit-com/uboot-2022.10.git $BAO_DEMOS_UBOOT\
+    --depth 1 --branch k3-br-v1.0.0
+make -C $BAO_DEMOS_UBOOT ARCH=riscv CROSS_COMPILE=$OPENSBI_CROSS_COMPILE\
+    k3_defconfig
+make -C $BAO_DEMOS_UBOOT ARCH=riscv CROSS_COMPILE=$OPENSBI_CROSS_COMPILE\
+    -j$(nproc)
+cp $BAO_DEMOS_UBOOT/u-boot.itb $BAO_DEMOS_UBOOT/u-boot-env-default.bin\
+    $BAO_DEMOS_UBOOT/FSBL.bin $BAO_DEMOS_UBOOT/bootinfo_block.bin\
+    $BAO_DEMOS_WRKDIR_PLAT
+```
+
+> U-Boot needs the Linux-targeting toolchain: the bare-metal one cannot link
+> its EFI applications.
+
+## 3) Package Bao and the boot script as FITs
+
+This board's U-Boot has the legacy image format disabled, so both Bao and the
+boot script are delivered as FITs: `bao.itb` (Bao + the guests, fixed
+load/entry `0x1_40000000`) and `boot.scr` (the script that loads + `bootm`'s
+`bao.itb`). `mkimage` resolves the `/incbin/` in each `.its` relative to the
+`.its` file's directory, so stage them next to `bao.bin` first:
+
+```
+cp $BAO_DEMOS/platforms/k3-com260/bao.its\
+    $BAO_DEMOS/platforms/k3-com260/boot.cmd\
+    $BAO_DEMOS/platforms/k3-com260/boot_scr.its $BAO_DEMOS_WRKDIR_IMGS
+cd $BAO_DEMOS_WRKDIR_IMGS
+mkimage -f bao.its bao.itb
+mkimage -f boot_scr.its boot.scr
+```
+
+## 4) Patch the U-Boot environment
+
+The vendor environment's `bootcmd` only knows how to boot grub or a raw Linux
+kernel; it never sources `boot.scr`. Rebuild the env image with a `bootcmd`
+that does (the image format is a 4-byte CRC32 followed by NUL-separated
+variables; `mkenvimage` regenerates it):
+
+```
+cd $BAO_DEMOS_WRKDIR_PLAT
+tail -c +5 u-boot-env-default.bin | tr '\0' '\n' | grep -aE '^[[:alnum:]_]+='\
+    | sed '/^bootcmd=/d' > u-boot-env-bao.txt
+echo 'bootcmd=mmc dev 0; if part number mmc 0 bootfs bootpart && load mmc 0:${bootpart} 0x140000000 boot.scr; then source 0x140000000; else run autoboot; fi'\
+    >> u-boot-env-bao.txt
+mkenvimage -s 0x4000 -p 0xff -o u-boot-env-bao.bin u-boot-env-bao.txt
+```
+
+<!--- instruction#1 -->
+## 5) Flash the SD card
+
+If you used the automated make, it already assembled a flashable SD-card image
+(`sdcard.img`), so just write it to a microSD card (find the DISK node with
+`lsblk` - NOT a partition; `dd` to the wrong disk destroys it):
+
+```
+sudo umount /dev/sdX* 2>/dev/null || true
+sudo dd if=${BAO_DEMOS_WRKDIR_IMGS}/sdcard.img of=/dev/sdX bs=4M status=progress conv=fsync
+sync
+```
+
+### …or build the card by hand
+
+The image is just a GPT with one `bootfs` partition plus firmware blobs `dd`'d to
+fixed offsets (the K3 BootROM/SPL find them by offset, not via the table - do not
+move them). This is exactly the `$(sdcard_img)` recipe in `make.mk`; run the same
+commands with `of=/dev/sdX` to write a card directly.
+
+```
+CARD=/dev/sdX                                  # the DISK node from lsblk
+
+# GPT + one 256 MiB bootfs partition at 12 MiB (sectors 24576..548863):
+sudo sgdisk --zap-all "$CARD"
+sudo sgdisk --clear -n 1:24576:548863 -c 1:bootfs "$CARD"
+
+# firmware to fixed offsets (seek is KiB, bs=1024):
+sudo dd if=${BAO_DEMOS_WRKDIR_PLAT}/u-boot-env-bao.bin                of="$CARD" bs=1024 seek=640  conv=notrunc,fsync    # env      @640K
+sudo dd if=${BAO_DEMOS_WRKDIR_PLAT}/bootinfo_block.bin                of="$CARD" bs=1024 seek=1024 conv=notrunc,fsync    # bootinfo @1M
+sudo dd if=${BAO_DEMOS_WRKDIR_PLAT}/FSBL.bin                          of="$CARD" bs=1024 seek=1536 conv=notrunc,fsync    # fsbl     @1536K
+sudo dd if=${BAO_DEMOS_WRKDIR_PLAT}/fw_dynamic.itb                    of="$CARD" bs=1024 seek=7168 conv=notrunc,fsync    # opensbi  @7M
+sudo dd if=${BAO_DEMOS_WRKDIR_PLAT}/u-boot.itb                        of="$CARD" bs=1024 seek=8192 conv=notrunc,fsync    # uboot    @8M
+
+# bootfs filesystem with bao.itb + boot.scr (+ u-boot.itb):
+sudo partprobe "$CARD"; sudo mkfs.ext4 -F -L bootfs "${CARD}1"   # ${CARD}p1 on mmc/nvme
+m=$(mktemp -d); sudo mount "${CARD}1" "$m"
+sudo cp ${BAO_DEMOS_WRKDIR_IMGS}/bao.itb ${BAO_DEMOS_WRKDIR_IMGS}/boot.scr \
+        ${BAO_DEMOS_WRKDIR_PLAT}/u-boot.itb "$m"/
+sync; sudo umount "$m"; rmdir "$m"
+```
+
+On a card that already has a working K3 layout, skip the firmware and just
+refresh `bootfs` with the new `bao.itb` + `boot.scr`:
+
+```
+m=$(mktemp -d); sudo mount "${CARD}1" "$m"                       # ${CARD}p1 on mmc/nvme
+sudo cp ${BAO_DEMOS_WRKDIR_IMGS}/bao.itb ${BAO_DEMOS_WRKDIR_IMGS}/boot.scr "$m"/
+sync; sudo umount "$m"; rmdir "$m"
+```
+
+Finally, insert the microSD card into the board's SD card slot.
+
+<!--- instruction#2 -->
+## 6) Connect the board
+
+**Serial (console)** - UART0 at **115200 8N1**. Use the onboard USB-serial debug
+port (enumerates as e.g. `/dev/ttyUSB0`), or an external 3.3 V USB-TTL/FTDI on the
+debug header (cross the data lines, leave VCC unconnected):
+
+```
+  board UART0 TX  ->  FTDI RX        screen /dev/ttyUSB0 115200
+  board UART0 RX  ->  FTDI TX
+  board GND       <-> FTDI GND
+```
+
+For the **baremetal** demo this is the guest console. For **linux+freertos** this
+is the **FreeRTOS** console (Linux has no serial console).
+
+> Confirm the exact debug-header pinout against the CoM260 user guide (it is
+> board-revision specific):
+> https://spacemit.com/community/document/info?lang=en&nodepath=hardware/eco/k3_com260/com260_user_guide.md
+
+<!--- instruction#3 -->
+## 7) Boot Bao
+
+Power on / reset: Bao boots unattended. On the serial console you can watch the
+whole chain unfold:
+
+1. The BootROM reads the bootinfo block from the card and loads the **FSBL**,
+   which brings up DDR.
+2. The FSBL loads **OpenSBI** (the resident M-mode firmware) and **U-Boot**
+   from their fixed offsets.
+3. U-Boot's `bootcmd` loads `boot.scr` from the `bootfs` partition and sources
+   it; the script stages `bao.itb` in DRAM and `bootm` unpacks **Bao** to its
+   fixed load address `0x140000000` and jumps to it.
+4. Bao prints its banner, copies the guest image(s) to their memory regions,
+   and starts the VMs.
+
+You should then see the guests' output on the UART console (and, depending on
+the demo, be able to reach a guest over the network): follow your specific
+demo's instructions for what to expect and how to interact with it.
+
+<!--- instruction#end -->

--- a/platforms/k3-com260/bao.its
+++ b/platforms/k3-com260/bao.its
@@ -1,0 +1,33 @@
+/dts-v1/;
+
+/ {
+	description = "Bao hypervisor for SpacemiT K3 (CoM260 Kit)";
+	#address-cells = <2>;
+
+	images {
+		bao {
+			description = "Bao hypervisor + guest(s)";
+			data = /incbin/("./bao.bin");
+			type = "kernel";
+			arch = "riscv";
+			os = "linux";
+			compression = "none";
+			/* Fixed, page-aligned load/entry inside DRAM (kernel_addr_r from the
+			 * vendor U-Boot env). U-Boot's RISC-V bootm enters with a0 = boot
+			 * hart id, a1 = FDT (Bao ignores a1). */
+			load = <0x1 0x40000000>;
+			entry = <0x1 0x40000000>;
+			hash {
+				algo = "crc32";
+			};
+		};
+	};
+
+	configurations {
+		default = "conf-bao";
+		conf-bao {
+			description = "Boot Bao";
+			kernel = "bao";
+		};
+	};
+};

--- a/platforms/k3-com260/boot.cmd
+++ b/platforms/k3-com260/boot.cmd
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Boot the Bao hypervisor on the SpacemiT K3 (CoM260 Kit) from U-Boot.
+# Compiled to boot.scr as a FIT (mkimage -f boot_scr.its boot.scr; this U-Boot
+# rejects legacy uImages) and placed on the bootfs partition next to bao.itb.
+
+# Staging address for the FIT file; must not overlap the kernel's fixed load
+# address 0x140000000 (baked into bao.itb). Both are well inside DRAM.
+setenv bao_stage 0x150000000
+
+setenv bao_mmc 0
+mmc dev ${bao_mmc}
+
+if part number mmc ${bao_mmc} bootfs bootpart; then
+	echo "Bao: bootfs is mmc ${bao_mmc}:${bootpart}"
+else
+	echo "Bao: 'bootfs' not found by name; using part 7"
+	setenv bootpart 7
+fi
+
+echo "Bao: loading bao.itb -> ${bao_stage}"
+load mmc ${bao_mmc}:${bootpart} ${bao_stage} bao.itb
+
+# Bao consumes only a0 (boot hart id); it ignores the FDT in a1, but bootm's FDT
+# stage still needs a valid tree, so pass U-Boot's resident control FDT.
+echo "Bao: booting..."
+bootm ${bao_stage} - ${fdtcontroladdr}

--- a/platforms/k3-com260/boot_scr.its
+++ b/platforms/k3-com260/boot_scr.its
@@ -1,0 +1,26 @@
+/dts-v1/;
+
+/*
+ * FIT wrapper for boot.cmd. This board's U-Boot has the legacy image format
+ * disabled (CONFIG_LEGACY_IMAGE_FORMAT unset), so a classic
+ * `mkimage -T script` boot.scr is rejected by `source` with
+ * "Wrong image format" - the script must be a FIT, just like bao.itb.
+ * The `default` property under /images lets a plain `source ${addr}`
+ * (no :unit-name suffix) find the script.
+ */
+
+/ {
+	description = "Bao boot script (FIT, this U-Boot rejects legacy uImages)";
+	#address-cells = <1>;
+
+	images {
+		default = "script";
+
+		script {
+			description = "boot.cmd";
+			data = /incbin/("boot.cmd");
+			type = "script";
+			compression = "none";
+		};
+	};
+};

--- a/platforms/k3-com260/make.mk
+++ b/platforms/k3-com260/make.mk
@@ -1,0 +1,126 @@
+ARCH:=riscv64
+
+# Linux is SpacemiT's vendor kernel. The standard guests/linux/make.mk flow
+# handles everything else: buildroot builds the kernel from this tree
+# (LINUX_OVERRIDE_SRCDIR) on its arch defconfig plus the bao-demos fragments
+# (configs/base.config + configs/k3-com260.config: SoC gate, CCU, pinctrl,
+# AIA, gmac, 8250) and embeds its rootfs (dropbear + the bao-drivers ipc
+# module + the S99bao init script) as the initramfs.
+linux_repo    := https://github.com/spacemit-com/linux-6.18.git
+linux_version := k3-br-v1.0.y
+
+# This board's U-Boot has the legacy image format disabled, so Bao is delivered
+# as a U-Boot FIT (bao.itb) plus a boot script (boot.scr). See README.md for the
+# OpenSBI/U-Boot and SD-card steps (and ../../deploy in the workspace root).
+bao_its  := $(platform_dir)/bao.its
+bao_itb  := $(wrkdir_demo_imgs)/bao.itb
+boot_scr := $(wrkdir_demo_imgs)/boot.scr
+
+$(bao_itb): $(bao_image) $(bao_its)
+	# mkimage resolves the FIT /incbin/ path relative to the .its file's own
+	# directory, so place the .its next to bao.bin before packaging.
+	cp $(bao_its) $(wrkdir_demo_imgs)/bao.its
+	cd $(wrkdir_demo_imgs) && mkimage -f bao.its bao.itb
+
+$(boot_scr): $(platform_dir)/boot.cmd $(platform_dir)/boot_scr.its
+	# boot.scr must ALSO be a FIT (`source` rejects legacy `mkimage -T script`
+	# images on this U-Boot). /incbin/ resolves next to the .its, so stage both.
+	cp $(platform_dir)/boot.cmd $(platform_dir)/boot_scr.its $(wrkdir_demo_imgs)/
+	cd $(wrkdir_demo_imgs) && mkimage -f boot_scr.its boot.scr
+
+# --- Boot firmware: OpenSBI + U-Boot from SpacemiT's repos -------------------
+# Reuse the stock opensbi.mk/uboot.mk fetch infrastructure, pointed at the
+# SpacemiT repos. Both build with the Linux-targeting RV64
+# toolchain already required for RISC-V demos (OPENSBI_CROSS_COMPILE). Only the
+# K3-specific packaging is local: OpenSBI as fw_dynamic.itb from k3_defconfig
+# (not the generic FW_PAYLOAD flow) and U-Boot as u-boot.itb + the default env.
+# Pin the k3-br-v1.0.0 TAGS, not the k3-br-v1.0.y branch: the branch moves and
+# its tip already broke once (SPL grew past the FSBL's 0x72f00 size limit).
+OPENSBI_CROSS_COMPILE    ?= riscv64-unknown-linux-gnu-
+override opensbi_repo    := https://github.com/spacemit-com/opensbi.git
+override opensbi_version := k3-br-v1.0.0
+include $(bao_demos)/platforms/opensbi.mk
+
+uboot_repo    := https://github.com/spacemit-com/uboot-2022.10.git
+uboot_version := k3-br-v1.0.0
+include $(bao_demos)/platforms/uboot.mk
+
+opensbi_itb := $(wrkdir_plat_imgs)/fw_dynamic.itb
+uboot_bin   := $(wrkdir_plat_imgs)/u-boot.bin
+uboot_itb   := $(wrkdir_plat_imgs)/u-boot.itb
+uboot_env   := $(wrkdir_plat_imgs)/u-boot-env-default.bin
+fsbl_bin    := $(wrkdir_plat_imgs)/FSBL.bin
+bootinfo    := $(wrkdir_plat_imgs)/bootinfo_block.bin
+
+# OpenSBI is loaded by the FSBL as fw_dynamic (SpacemiT wraps it as an itb).
+$(eval $(call build-opensbi-dynamic, $(opensbi_itb), k3_defconfig))
+
+# U-Boot cannot build with the default bare-metal toolchain (its EFI apps need
+# a linker with shared-object support), so force the linux-gnu one.
+$(eval $(call build-uboot, $(uboot_bin), k3_defconfig,, \
+	ARCH=riscv CROSS_COMPILE=$(OPENSBI_CROSS_COMPILE)))
+
+# The same U-Boot build also produces everything else the K3 boot flow needs:
+# the FIT (u-boot.itb), the default env image, the FSBL (the signed SPL the
+# BootROM loads) and the bootinfo block that points the BootROM at it.
+$(uboot_itb) $(uboot_env) $(fsbl_bin) $(bootinfo): $(uboot_bin)
+	cp $(uboot_src)/u-boot.itb $(uboot_itb)
+	cp $(uboot_src)/u-boot-env-default.bin $(uboot_env)
+	cp $(uboot_src)/FSBL.bin $(fsbl_bin)
+	cp $(uboot_src)/bootinfo_block.bin $(bootinfo)
+
+opensbi: $(opensbi_itb)
+
+# The vendor env's bootcmd (run autoboot -> mmc_boot) only knows how to boot
+# grub or a raw Linux kernel; it never sources boot.scr. Swap bootcmd for one
+# that does, so a freshly flashed card boots Bao unattended. The env image is
+# 4-byte CRC32 + NUL-separated vars + 0xff padding; mkenvimage rebuilds it.
+uboot_env_bao := $(wrkdir_plat_imgs)/u-boot-env-bao.bin
+
+$(uboot_env_bao): $(uboot_env)
+	tail -c +5 $< | tr '\0' '\n' | grep -aE '^[[:alnum:]_]+=' | \
+		sed '/^bootcmd=/d' > $@.txt
+	printf '%s\n' 'bootcmd=mmc dev 0; if part number mmc 0 bootfs bootpart && load mmc 0:$${bootpart} 0x140000000 boot.scr; then source 0x140000000; else run autoboot; fi' >> $@.txt
+	mkenvimage -s 0x4000 -p 0xff -o $@ $@.txt
+
+# --- Flashable SD-card image -------------------------------------------------
+# The K3 boot chain (BootROM -> FSBL -> OpenSBI -> U-Boot -> Bao) finds the early
+# stages by FIXED byte offset, not via the partition table, so the firmware is
+# dd'd into raw gaps before the single GPT 'bootfs' partition (which holds
+# bao.itb + boot.scr). The offsets below are the vendor K3 layout - do NOT move
+# the firmware ones (bootinfo points the BootROM at FSBL@1536K). These exact
+# steps also work BY HAND on a real card: same sgdisk/dd with of=/dev/sdX (the
+# disk, not a partition) under sudo - see the README.
+sdcard_img := $(wrkdir_demo_imgs)/sdcard.img
+
+$(sdcard_img): $(bao_itb) $(boot_scr) $(opensbi_itb) $(uboot_itb) $(uboot_env_bao) \
+		$(fsbl_bin) $(bootinfo)
+	# 1) bootfs: a 256 MiB ext4 holding bao.itb + boot.scr (+ u-boot.itb).
+	rm -rf $(@D)/bootfs-root && mkdir -p $(@D)/bootfs-root
+	cp $(bao_itb) $(boot_scr) $(uboot_itb) $(@D)/bootfs-root/
+	mke2fs -q -t ext4 -L bootfs -d $(@D)/bootfs-root $(@D)/bootfs.ext4 256M
+	# 2) empty 270 MiB image + GPT with one 'bootfs' partition at 12 MiB / 256 MiB.
+	rm -f $@ && truncate -s 270M $@
+	sgdisk --clear -n 1:24576:548863 -c 1:bootfs $@ >/dev/null
+	# 3) place each blob at its offset (seek is in KiB because bs=1024):
+	dd if=$(uboot_env_bao) of=$@ bs=1024 seek=640   conv=notrunc status=none # env      @640K
+	dd if=$(bootinfo)      of=$@ bs=1024 seek=1024  conv=notrunc status=none # bootinfo @1M
+	dd if=$(fsbl_bin)      of=$@ bs=1024 seek=1536  conv=notrunc status=none # fsbl     @1536K
+	dd if=$(opensbi_itb)                     of=$@ bs=1024 seek=7168  conv=notrunc status=none # opensbi  @7M
+	dd if=$(uboot_itb)                       of=$@ bs=1024 seek=8192  conv=notrunc status=none # uboot    @8M
+	dd if=$(@D)/bootfs.ext4                  of=$@ bs=1024 seek=12288 conv=notrunc status=none # bootfs   @12M
+
+sdcard: $(sdcard_img)
+	@echo "SD image ready: $(sdcard_img)"
+	@echo "Flash: sudo dd if=$(sdcard_img) of=/dev/sdX bs=4M status=progress conv=fsync; sync"
+
+# Building the platform (the default `all` goal) now produces the flashable
+# sdcard.img directly: $(sdcard_img) pulls in bao.itb + boot.scr + OpenSBI +
+# U-Boot, so a single `make ... PLATFORM=k3-com260 DEMO=<demo>` yields a card
+# ready to dd. Use the `sdcard` target if you only want the image + flash hint.
+instructions:=$(platform_dir)/README.md
+platform: $(sdcard_img)
+	@echo "==> SD card image ready: $(sdcard_img)"
+	$(call print-instructions, $(instructions), 1, false)
+	$(call print-instructions, $(instructions), 2, false)
+	$(call print-instructions, $(instructions), 3, true)

--- a/platforms/opensbi.mk
+++ b/platforms/opensbi.mk
@@ -20,3 +20,16 @@ $(strip $1): $(strip $2) $(opensbi_src)
 		FW_PAYLOAD_PATH=$(strip $2)
 	cp $(opensbi_src)/build/platform/generic/firmware/fw_payload.bin $$@
 endef
+
+# Build the dynamic firmware (fw_dynamic) for boot flows where an earlier
+# stage (e.g. a vendor SPL) loads OpenSBI and the next stage separately,
+# optionally with a platform defconfig ($2). The produced artifact is selected
+# by the target's file name ($1), e.g. fw_dynamic.bin or a vendor fw_dynamic.itb.
+define build-opensbi-dynamic
+$(strip $1): | $(opensbi_src)
+	$(MAKE) -C $(opensbi_src) \
+		CROSS_COMPILE=$(OPENSBI_CROSS_COMPILE) \
+		PLATFORM=generic \
+		$(if $(strip $2),PLATFORM_DEFCONFIG=$(strip $2))
+	cp $(opensbi_src)/build/platform/generic/firmware/$$(notdir $$@) $$@
+endef

--- a/platforms/qemu-riscv64-virt/README.md
+++ b/platforms/qemu-riscv64-virt/README.md
@@ -32,8 +32,8 @@ make -C $BAO_DEMOS_OPENSBI PLATFORM=generic \
     FW_PAYLOAD=y \
     FW_PAYLOAD_FDT_ADDR=0x80100000\
     FW_PAYLOAD_PATH=$BAO_DEMOS_WRKDIR_IMGS/bao.bin
-cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.elf\
-    $BAO_DEMOS_WRKDIR_IMGS/opensbi.elf
+cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.bin\
+    $BAO_DEMOS_WRKDIR_IMGS/opensbi.bin
 ```
 
 ## 3) Run QEMU
@@ -41,7 +41,7 @@ cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.elf\
 ```
  qemu-system-riscv64 -nographic\
     -M virt -cpu rv64 -m 4G -smp 4\
-    -bios $BAO_DEMOS_WRKDIR_IMGS/opensbi.elf\
+    -bios $BAO_DEMOS_WRKDIR_IMGS/opensbi.bin\
     -device virtio-net-device,netdev=net0 \
     -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\
     -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3 -S

--- a/platforms/uboot.mk
+++ b/platforms/uboot.mk
@@ -8,11 +8,15 @@ ifneq (,$(filter $(PLATFORM),zcu102 zcu104))
 	git -C $(uboot_src) apply $(bao_demos)/platforms/$(PLATFORM)/u-boot.patch
 endif
 
+# $1: target u-boot.bin path; $2: defconfig; $3: .config fragment to append;
+# $4 (optional): extra make arguments for both invocations (e.g. a
+# CROSS_COMPILE= override for boards that cannot build with the default
+# bare-metal toolchain).
 define build-uboot
 $(strip $1): $(uboot_src)
-	$(MAKE) -C $(uboot_src) $(strip $2)
+	$(MAKE) -C $(uboot_src) $(strip $4) $(strip $2)
 	echo $(strip $3) >> $(uboot_src)/.config
-	$(MAKE) -C $(uboot_src) -j$(nproc) 
+	$(MAKE) -C $(uboot_src) $(strip $4) -j$(nproc)
 	cp $(uboot_src)/u-boot.bin $$@
 	[ -f $(uboot_src)/u-boot.elf ] && cp $(uboot_src)/u-boot.elf $(wrkdir_plat_imgs)/u-boot.elf 2>/dev/null || true
 	[ -f $(uboot_src)/u-boot-nodtb.bin ] && cp $(uboot_src)/u-boot-nodtb.bin $(wrkdir_plat_imgs)/$(DEMO)/u-boot-nodtb.bin 2>/dev/null || true


### PR DESCRIPTION
Adds the **`k3-com260`** platform (SpacemiT K3 / CoM260 Kit, a.k.a. Banana Pi BPI-SM10) with the **baremetal** and **linux+freertos** demos. Boot chain: `BootROM → FSBL → OpenSBI → U-Boot → Bao`.

One `make PLATFORM=k3-com260 DEMO=<baremetal|linux+freertos>` fetches and builds everything and assembles a flashable `sdcard.img`. Both demos boot on real hardware.

Also includes some small generic bits used by the platform: a `build-opensbi-dynamic` macro, an optional extra-args parameter for `build-uboot`, an `envsubst` fix in `print-instructions`, and moving the demos to the `demo-next` branches.

**Depends on** bao-project/bao-hypervisor#369 being merged and `bao-hypervisor`'s `demo-next` branch bumped to include it.
