### PR TITLE
fix(qemu-riscv64): gate Svpbmt CPU flag on RISCV_XLEN for QEMU

### DIFF
--- a/platforms/qemu-riscv64-virt/README.md
+++ b/platforms/qemu-riscv64-virt/README.md
@@ -42,7 +42,7 @@ cp $BAO_DEMOS_OPENSBI/build/platform/generic/firmware/fw_payload.bin\
 
 ```
  qemu-system-riscv64 -nographic\
-    -M virt -cpu rv64 -m 4G -smp 4\
+    -M virt -cpu rv64,priv_spec=v1.13.0,sstc=true,svpbmt=true -m 4G -smp 4\
     -bios $BAO_DEMOS_WRKDIR_IMGS/opensbi.bin\
     -device virtio-net-device,netdev=net0 \
     -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\

--- a/platforms/qemu-riscv64-virt/make.mk
+++ b/platforms/qemu-riscv64-virt/make.mk
@@ -9,11 +9,16 @@ $(eval $(call build-opensbi-payload, $(opensbi_image), $(bao_image), $(RISCV_XLE
 
 platform: $(opensbi_image)
 
+qemu_cpu_ext:=priv_spec=v1.13.0,sstc=true
+ifeq ($(RISCV_XLEN),64)
+qemu_cpu_ext:=$(qemu_cpu_ext),svpbmt=true
+endif
+
 instructions:=$(bao_demos)/platforms/$(PLATFORM)/README.md
 run: qemu platform
 	$(call print-instructions, $(instructions), 1, true)
 	$(qemu_cmd) -nographic\
-		-M virt -cpu rv$(RISCV_XLEN),priv_spec=v1.13.0,sstc=true -m 4G -smp 4\
+		-M virt -cpu rv$(RISCV_XLEN),$(qemu_cpu_ext) -m 4G -smp 4\
 		-bios $(opensbi_image)\
 		-device virtio-net-device,netdev=net0\
 		-netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\


### PR DESCRIPTION
This PR forces the append of `svpbmt=true` qemu option when `RISCV_XLEN` is 64.