### PR TITLE
fix(qemu): bump pinned QEMU to v11.1.0-rc1

### DIFF
--- a/platforms/qemu-riscv32-virt/README.md
+++ b/platforms/qemu-riscv32-virt/README.md
@@ -15,7 +15,7 @@ make sure you are using version 7.2.0 or higher. If so, you can skip this step.
 ```
 export BAO_DEMOS_QEMU=$BAO_DEMOS_WRKDIR_SRC/qemu-$ARCH
 git clone https://github.com/qemu/qemu.git $BAO_DEMOS_QEMU --depth 1\
-   --branch v11.1.0-rc0
+   --branch v11.1.0-rc1
 cd $BAO_DEMOS_QEMU
 ./configure --target-list=riscv32-softmmu --enable-slirp
 make -j$(nproc)

--- a/platforms/qemu-riscv64-virt/README.md
+++ b/platforms/qemu-riscv64-virt/README.md
@@ -15,7 +15,7 @@ make sure you are using version 7.2.0 or higher. If so, you can skip this step.
 ```
 export BAO_DEMOS_QEMU=$BAO_DEMOS_WRKDIR_SRC/qemu-$ARCH
 git clone https://github.com/qemu/qemu.git $BAO_DEMOS_QEMU --depth 1\
-   --branch v10.0.2 
+   --branch v11.1.0-rc1
 cd $BAO_DEMOS_QEMU
 ./configure --target-list=riscv64-softmmu --enable-slirp
 make -j$(nproc)

--- a/platforms/qemu.mk
+++ b/platforms/qemu.mk
@@ -4,7 +4,7 @@ qemu_arch:=arm
 endif
 
 qemu_repo:=https://github.com/qemu/qemu.git
-qemu_version:=v11.0.2
+qemu_version:=v11.1.0-rc1
 qemu_cmd:=qemu-system-$(qemu_arch)
 
 ifeq ($(shell which $(qemu_cmd)),)


### PR DESCRIPTION
RV32 guests using Sstc under a hypervisor are broken up to QEMU v11.0.2: a write to the low half of henvcfg wipes henvcfgh, including the STCE bit, so guest stimecmp accesses raise virtual-instruction faults once the hypervisor touches henvcfg's low bits. This was fixed upstream in QEMU and first shipped in v11.1.0-rc0.

Bump the pinned QEMU to v11.1.0-rc1 and align the RISC-V platform READMEs with the pinned version (the rv64 one still said v10.0.2, the rv32 one v11.1.0-rc0).

Note the pin in platforms/qemu.mk is shared, so aarch64 builds also move to v11.1.0-rc1; the qemu-aarch64-virt README still references v10.0.2 and could be aligned separately.