### PR TITLE
feat(qemu-riscv): move QEMU RISC-V platforms from PLIC to AIA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ environment+=BAO_DEMOS_SDCARD=/media/$$USER/boot
 all: platform
 
 bao_repo:=https://github.com/bao-project/bao-hypervisor
-bao_version:=997ba1dd811f6728ee2694f7876907b5528ded6c
+bao_version:=738e3dc50983b4653ce63410368f65b75a627585
 bao_src:=$(wrkdir_src)/bao
 bao_cfg_repo:=$(wrkdir_demo_imgs)/config
 wrkdirs+=$(bao_cfg_repo)

--- a/demos/baremetal/configs/qemu-riscv64-virt.c
+++ b/demos/baremetal/configs/qemu-riscv64-virt.c
@@ -40,7 +40,8 @@ struct config config  = {
                 },
 
                 .arch = {
-                   .irqc.plic.base = 0xc000000,
+                   .irqc.aia.aplic.base = 0xd000000,
+                   .irqc.aia.imsic.base = 0x28000000,
                 }
             },
         },

--- a/demos/linux+freertos/configs/qemu-riscv32-virt.c
+++ b/demos/linux+freertos/configs/qemu-riscv32-virt.c
@@ -60,7 +60,8 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic.base = 0xc000000,
+                    .irqc.aia.aplic.base = 0xd000000,
+                    .irqc.aia.imsic.base = 0x28000000,
                 }
             },
         },
@@ -107,7 +108,8 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic.base = 0xc000000,
+                    .irqc.aia.aplic.base = 0xd000000,
+                    .irqc.aia.imsic.base = 0x28000000,
                 }
             },
         },

--- a/demos/linux+freertos/configs/qemu-riscv64-virt.c
+++ b/demos/linux+freertos/configs/qemu-riscv64-virt.c
@@ -60,7 +60,8 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic.base = 0xc000000,
+                    .irqc.aia.aplic.base = 0xd000000,
+                    .irqc.aia.imsic.base = 0x28000000,
                 }
             },
         },
@@ -107,7 +108,8 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic.base = 0xc000000,
+                    .irqc.aia.aplic.base = 0xd000000,
+                    .irqc.aia.imsic.base = 0x28000000,
                 }
             },
         },

--- a/demos/linux+freertos/devicetrees/qemu-riscv32-virt/linux.dts
+++ b/demos/linux+freertos/devicetrees/qemu-riscv32-virt/linux.dts
@@ -15,7 +15,7 @@
 			reg = <0x00>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv32";
 
 			cpu0_intc: interrupt-controller {
@@ -31,7 +31,7 @@
 			reg = <0x01>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv32";
 
 			cpu1_intc: interrupt-controller {
@@ -47,7 +47,7 @@
 			reg = <0x02>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv32imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv32";
 
 			cpu2_intc: interrupt-controller {
@@ -65,71 +65,81 @@
 		reg = <0x0 0x90000000 0x0 0x20000000>;
 	};
 
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
+	imsic: interrupt-controller@28000000 {
+		riscv,num-ids = <255>;
+		reg = <0x0 0x28000000 0x0 0x3000>;
 		interrupts-extended = <
-			&cpu0_intc 11 &cpu0_intc 9 
-			&cpu1_intc 11 &cpu1_intc 9 
-			&cpu2_intc 11 &cpu2_intc 9
+			&cpu0_intc 9
+			&cpu1_intc 9
+			&cpu2_intc 9
 		>;
+		msi-controller;
 		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+		compatible = "riscv,imsics";
+		#interrupt-cells = <0x0>;
+	};
+
+	aplic: interrupt-controller@d000000 {
+		riscv,num-sources = <96>;
+		reg = <0x0 0xd000000 0x0 0x8000>;
+		msi-parent = <&imsic>;
+		interrupt-controller;
+		compatible = "riscv,aplic";
+		#interrupt-cells = <0x2>;
 	};
 
 	virtio_mmio@10008000 {
-		interrupts = <0x8>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x8 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10008000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10007000 {
-		interrupts = <0x7>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x7 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10007000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10006000 {
-		interrupts = <0x6>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x6 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10006000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10005000 {
-		interrupts = <0x5>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x5 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10005000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10004000 {
-		interrupts = <0x4>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x4 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10004000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10003000 {
-		interrupts = <0x3>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x3 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10003000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10002000 {
-		interrupts = <0x2>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x2 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10002000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10001000 {
-		interrupts = <0x1>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x1 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10001000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
@@ -139,8 +149,8 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-		interrupt-parent = <&plic>;
-        interrupts = <52>;
+		interrupt-parent = <&aplic>;
+        interrupts = <52 4>;
 		id = <0>;
     };
 

--- a/demos/linux+freertos/devicetrees/qemu-riscv64-virt/linux.dts
+++ b/demos/linux+freertos/devicetrees/qemu-riscv64-virt/linux.dts
@@ -14,7 +14,7 @@
 			reg = <0x0>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv48";
 
 			cpu0_intc: interrupt-controller {
@@ -29,7 +29,7 @@
 			reg = <0x1>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv48";
 
 			cpu1_intc: interrupt-controller {
@@ -44,7 +44,7 @@
 			reg = <0x2>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_sstc";
+			riscv,isa = "rv64imafdch_zicntr_zicsr_zifencei_ssaia_sstc";
 			mmu-type = "riscv,sv48";
 
 			cpu2_intc: interrupt-controller {
@@ -60,71 +60,81 @@
 		reg = <0x0 0x90000000 0x0 0x40000000>;
 	};
 
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
+	imsic: interrupt-controller@28000000 {
+		riscv,num-ids = <255>;
+		reg = <0x0 0x28000000 0x0 0x3000>;
 		interrupts-extended = <
-			&cpu0_intc 11 &cpu0_intc 9 
-			&cpu1_intc 11 &cpu1_intc 9 
-			&cpu2_intc 11 &cpu2_intc 9
+			&cpu0_intc 9
+			&cpu1_intc 9
+			&cpu2_intc 9
 		>;
+		msi-controller;
 		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+		compatible = "riscv,imsics";
+		#interrupt-cells = <0x0>;
+	};
+
+	aplic: interrupt-controller@d000000 {
+		riscv,num-sources = <96>;
+		reg = <0x0 0xd000000 0x0 0x8000>;
+		msi-parent = <&imsic>;
+		interrupt-controller;
+		compatible = "riscv,aplic";
+		#interrupt-cells = <0x2>;
 	};
 
 	virtio_mmio@10008000 {
-		interrupts = <0x8>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x8 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10008000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10007000 {
-		interrupts = <0x7>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x7 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10007000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10006000 {
-		interrupts = <0x6>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x6 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10006000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10005000 {
-		interrupts = <0x5>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x5 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10005000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10004000 {
-		interrupts = <0x4>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x4 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10004000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10003000 {
-		interrupts = <0x3>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x3 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10003000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10002000 {
-		interrupts = <0x2>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x2 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10002000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10001000 {
-		interrupts = <0x1>;
-		interrupt-parent = <&plic>;
+		interrupts = <0x1 4>;
+		interrupt-parent = <&aplic>;
 		reg = <0x0 0x10001000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
@@ -134,8 +144,8 @@
         reg = <0x0 0xf0000000 0x0 0x00010000>;
 		read-channel = <0x0 0x2000>;
 		write-channel = <0x2000 0x2000>;
-		interrupt-parent = <&plic>;
-        interrupts = <52>;
+		interrupt-parent = <&aplic>;
+        interrupts = <52 4>;
 		id = <0>;
     };
 

--- a/demos/virtio/configs/qemu-riscv64-virt.c
+++ b/demos/virtio/configs/qemu-riscv64-virt.c
@@ -110,8 +110,9 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic = {
-                        .base = 0xC000000,
+                    .irqc.aia = {
+                        .aplic.base = 0xD000000,
+                        .imsic.base = 0x28000000,
                     }
                 }
             },
@@ -166,8 +167,9 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic = {
-                        .base = 0xC000000,
+                    .irqc.aia = {
+                        .aplic.base = 0xD000000,
+                        .imsic.base = 0x28000000,
                     }
                 }
             },
@@ -222,8 +224,9 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic = {
-                        .base = 0xC000000,
+                    .irqc.aia = {
+                        .aplic.base = 0xD000000,
+                        .imsic.base = 0x28000000,
                     }
                 }
             },
@@ -278,8 +281,9 @@ struct config config = {
                 },
 
                 .arch = {
-                    .irqc.plic = {
-                        .base = 0xC000000,
+                    .irqc.aia = {
+                        .aplic.base = 0xD000000,
+                        .imsic.base = 0x28000000,
                     }
                 }
             },

--- a/demos/virtio/devicetrees/qemu-riscv64-virt/linux-backend.dts
+++ b/demos/virtio/devicetrees/qemu-riscv64-virt/linux-backend.dts
@@ -14,7 +14,7 @@
 			reg = <0x0>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdcsu";
+			riscv,isa = "rv64imafdcsu_ssaia";
 			mmu-type = "riscv,sv48";
 
 			cpu0_intc: interrupt-controller {
@@ -30,15 +30,25 @@
 		reg = <0x0 0x90000000 0x0 0x40000000>;
 	};
 
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
+	imsic: interrupt-controller@28000000 {
+		riscv,num-ids = <255>;
+		reg = <0x0 0x28000000 0x0 0x1000>;
 		interrupts-extended = <
-			&cpu0_intc 11 &cpu0_intc 9 
+			&cpu0_intc 9
 		>;
+		msi-controller;
 		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+		compatible = "riscv,imsics";
+		#interrupt-cells = <0x0>;
+	};
+
+	aplic: interrupt-controller@d000000 {
+		riscv,num-sources = <96>;
+		reg = <0x0 0xd000000 0x0 0x8000>;
+		msi-parent = <&imsic>;
+		interrupt-controller;
+		compatible = "riscv,aplic";
+		#interrupt-cells = <0x2>;
 	};
 
 	bao_io_dispatcher: bao-io-dispatcher {
@@ -48,62 +58,62 @@
                0x0 0xd2000000 0x0 0x01000000
                0x0 0xd3000000 0x0 0x01000000
                0x0 0xd4000000 0x0 0x01000000>;
-		interrupts = <36 37 38 39 40>;
-		interrupt-parent = <&plic>;
+		interrupts = <36 4 37 4 38 4 39 4 40 4>;
+		interrupt-parent = <&aplic>;
 	};
 
 	virtio_mmio@10001000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x1>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x1 4>;
 		reg = <0x0 0x10001000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10002000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x2>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x2 4>;
 		reg = <0x0 0x10002000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10003000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x3>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x3 4>;
 		reg = <0x0 0x10003000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10004000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x4>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x4 4>;
 		reg = <0x0 0x10004000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 	
 	virtio_mmio@10005000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x5>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x5 4>;
 		reg = <0x0 0x10005000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10006000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x6>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x6 4>;
 		reg = <0x0 0x10006000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10007000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x7>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x7 4>;
 		reg = <0x0 0x10007000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@10008000 {
-		interrupt-parent = <&plic>;
-		interrupts = <0x8>;
+		interrupt-parent = <&aplic>;
+		interrupts = <0x8 4>;
 		reg = <0x0 0x10008000 0x0 0x1000>;
 		compatible = "virtio,mmio";
 	};

--- a/demos/virtio/devicetrees/qemu-riscv64-virt/linux-frontend1.dts
+++ b/demos/virtio/devicetrees/qemu-riscv64-virt/linux-frontend1.dts
@@ -14,7 +14,7 @@
 			reg = <0x0>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdcsu";
+			riscv,isa = "rv64imafdcsu_ssaia";
 			mmu-type = "riscv,sv48";
 
 			cpu0_intc: interrupt-controller {
@@ -47,28 +47,38 @@
 		};
     };
 
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
+	imsic: interrupt-controller@28000000 {
+		riscv,num-ids = <255>;
+		reg = <0x0 0x28000000 0x0 0x1000>;
 		interrupts-extended = <
-			&cpu0_intc 11 &cpu0_intc 9 
+			&cpu0_intc 9
 		>;
+		msi-controller;
 		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+		compatible = "riscv,imsics";
+		#interrupt-cells = <0x0>;
+	};
+
+	aplic: interrupt-controller@d000000 {
+		riscv,num-sources = <96>;
+		reg = <0x0 0xd000000 0x0 0x8000>;
+		msi-parent = <&imsic>;
+		interrupt-controller;
+		compatible = "riscv,aplic";
+		#interrupt-cells = <0x2>;
 	};
 
 	virtio@a003e00 {
-		interrupt-parent = <&plic>;
-		interrupts = <79>;
+		interrupt-parent = <&aplic>;
+		interrupts = <79 4>;
 		reg = <0x0 0xa003e00 0x0 0x200>;
 		compatible = "virtio,mmio";
 		memory-region = <&reserved1>;	
 	};
 
 	virtio@a003c00 {
-		interrupt-parent = <&plic>;
-		interrupts = <78>;
+		interrupt-parent = <&aplic>;
+		interrupts = <78 4>;
 		reg = <0x0 0xa003c00 0x0 0x200>;
 		compatible = "virtio,mmio";
 		memory-region = <&reserved2>;	

--- a/demos/virtio/devicetrees/qemu-riscv64-virt/linux-frontend2.dts
+++ b/demos/virtio/devicetrees/qemu-riscv64-virt/linux-frontend2.dts
@@ -14,7 +14,7 @@
 			reg = <0x0>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv64imafdcsu";
+			riscv,isa = "rv64imafdcsu_ssaia";
 			mmu-type = "riscv,sv48";
 
 			cpu0_intc: interrupt-controller {
@@ -47,28 +47,38 @@
 		};
     };
 
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
+	imsic: interrupt-controller@28000000 {
+		riscv,num-ids = <255>;
+		reg = <0x0 0x28000000 0x0 0x1000>;
 		interrupts-extended = <
-			&cpu0_intc 11 &cpu0_intc 9 
+			&cpu0_intc 9
 		>;
+		msi-controller;
 		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+		compatible = "riscv,imsics";
+		#interrupt-cells = <0x0>;
+	};
+
+	aplic: interrupt-controller@d000000 {
+		riscv,num-sources = <96>;
+		reg = <0x0 0xd000000 0x0 0x8000>;
+		msi-parent = <&imsic>;
+		interrupt-controller;
+		compatible = "riscv,aplic";
+		#interrupt-cells = <0x2>;
 	};
 
 	virtio@a003e00 {
-		interrupt-parent = <&plic>;
-		interrupts = <79>;
+		interrupt-parent = <&aplic>;
+		interrupts = <79 4>;
 		reg = <0x0 0xa003e00 0x0 0x200>;
 		compatible = "virtio,mmio";
 		memory-region = <&reserved1>;	
 	};
 
 	virtio@a003c00 {
-		interrupt-parent = <&plic>;
-		interrupts = <78>;
+		interrupt-parent = <&aplic>;
+		interrupts = <78 4>;
 		reg = <0x0 0xa003c00 0x0 0x200>;
 		compatible = "virtio,mmio";
 		memory-region = <&reserved2>;	

--- a/guests/baremetal/make.mk
+++ b/guests/baremetal/make.mk
@@ -1,6 +1,6 @@
 baremetal_src:=$(wrkdir_src)/baremetal
 baremetal_repo:=https://github.com/bao-project/bao-baremetal-guest.git
-baremetal_version:=ec644fb2a915617f12d937f81245b429f01697f3
+baremetal_version:=7c3a0f3c9f81e8a2fe34af6db1e39efb81c166af
 
 $(baremetal_src):
 	git clone $(baremetal_repo) $@

--- a/guests/freertos/make.mk
+++ b/guests/freertos/make.mk
@@ -1,6 +1,6 @@
 freertos_src:=$(wrkdir_src)/freertos
 freertos_repo:=https://github.com/bao-project/freertos-over-bao.git
-freertos_version:=cb9112f982c2768872536b811e013254d0184811
+freertos_version:=b8166a8627b4ac9778f7a4872997fa5197e46c2d
 
 $(freertos_src):
 	git clone $(freertos_repo) $@

--- a/guests/linux/buildroot/external/package/bao-drivers/bao-drivers.mk
+++ b/guests/linux/buildroot/external/package/bao-drivers/bao-drivers.mk
@@ -4,7 +4,7 @@ BAO_DRIVERS_VERSION = linux-v6.6
 else ifneq (,$(filter $(PLATFORM),k3-com260))
 BAO_DRIVERS_VERSION = linux-v6.18
 else
-BAO_DRIVERS_VERSION = linux-v6.15
+BAO_DRIVERS_VERSION = 76ed4153feb3fa2460dcf1f6e00ffedd98059dc5
 endif
 
 BAO_DRIVERS_SITE_METHOD = git

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -18,7 +18,8 @@ well as RISC-V using RV64:
 * [FVP-R Aarch32](fvp-r-aarch32/README.md)
 
 #### RISC-V platforms:
-* [QEMU virt](qemu-riscv64-virt/README.md)
+* [QEMU virt RV64](qemu-riscv64-virt/README.md)
+* [QEMU virt RV32](qemu-riscv32-virt/README.md)
 
 #### RH850 platforms:
 * [RH850 U2A16](rh850-u2a16/README.md)

--- a/platforms/qemu-riscv64-virt/make.mk
+++ b/platforms/qemu-riscv64-virt/make.mk
@@ -1,6 +1,7 @@
 RISCV_XLEN?=64
 ARCH:=riscv$(RISCV_XLEN)
 
+
 include $(bao_demos)/platforms/qemu.mk
 include $(bao_demos)/platforms/opensbi.mk
 
@@ -18,7 +19,7 @@ instructions:=$(bao_demos)/platforms/$(PLATFORM)/README.md
 run: qemu platform
 	$(call print-instructions, $(instructions), 1, true)
 	$(qemu_cmd) -nographic\
-		-M virt -cpu rv$(RISCV_XLEN),$(qemu_cpu_ext) -m 4G -smp 4\
+		-M virt,aia=aplic-imsic,aia-guests=1 -cpu rv$(RISCV_XLEN),$(qemu_cpu_ext) -m 4G -smp 4\
 		-bios $(opensbi_image)\
 		-device virtio-net-device,netdev=net0\
 		-netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22\


### PR DESCRIPTION
Switches qemu-riscv64-virt and qemu-riscv32-virt from the PLIC to AIA (APLIC + IMSIC): QEMU boots with aia=aplic-imsic, the VM configs and the Linux guest devicetrees describe the APLIC/IMSIC, and the bao and baremetal pins move to the revisions where AIA is the default, so nothing is forced at build time. FreeRTOS still embeds a PLIC-defaulting baremetal-runtime and is built with IRQC=AIA until its submodule is updated.

Also carries a bao-linux-drivers patch fixing remote I/O request delivery on AIA. This PR should only go ahead now that bao-project/bao-linux-drivers#6 is merged; the carried patch can be dropped once the linux-v6.15 tag resolved by buildroot moves past it.

RV32 guests using Sstc require QEMU v11.1.0-rc1 (#98).

Validated on qemu-riscv64-virt and qemu-riscv32-virt: baremetal, linux+freertos and virtio (rv64) demos.