### PR TITLE
fix(guests/zephyr): add pinctrl support to mps3-an536 board

### DIFF
--- a/guests/zephyr/boards/arm/baovm_mps3-an536/CMakeLists.txt
+++ b/guests/zephyr/boards/arm/baovm_mps3-an536/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) Bao Project and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reuse the mps3 SoC pinctrl_soc.h; this board sits on the fvp_aemv8r SoC,
+# which provides none, but drivers such as the CMSDK UART select PINCTRL.
+zephyr_include_directories(${ZEPHYR_BASE}/soc/arm/mps3)
+zephyr_sources_ifdef(CONFIG_PINCTRL pinctrl_stub.c)

--- a/guests/zephyr/boards/arm/baovm_mps3-an536/pinctrl_stub.c
+++ b/guests/zephyr/boards/arm/baovm_mps3-an536/pinctrl_stub.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/pinctrl.h>
+
+/*
+ * Pin muxing is not exposed to the guest VM and the board devicetree defines
+ * no pinctrl states, so this only satisfies the link-time dependency of
+ * drivers that select PINCTRL (e.g. the CMSDK UART).
+ */
+int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
+			   uintptr_t reg)
+{
+	ARG_UNUSED(pins);
+	ARG_UNUSED(pin_cnt);
+	ARG_UNUSED(reg);
+
+	return 0;
+}


### PR DESCRIPTION
Since the re-pin of all Zephyr guests to an upstream main snapshot (#100), the CMSDK UART driver selects `PINCTRL`, and `zephyr/drivers/pinctrl.h` unconditionally includes the SoC-provided `pinctrl_soc.h`. The `fvp_aemv8r` SoC the `baovm_mps3-an536` board builds on provides neither the header nor a `pinctrl_configure_pins()` implementation, so the mps3-an536 Zephyr demos no longer build:

```
zephyr/include/zephyr/drivers/pinctrl.h:29:10: fatal error: pinctrl_soc.h: No such file or directory
```

This reuses the mps3 SoC's `pinctrl_soc.h` by adding `soc/arm/mps3` to the include path (the same way upstream's own MPS3 boards get it) and adds a stub `pinctrl_configure_pins()` to satisfy the link. Reusing upstream's `pinctrl_arm_mps3.c` instead was considered, but it links against the CMSDK GPIO driver, which would require adding the GPIO nodes to the VM devicetree and mapping their MMIO into the guest for code that never runs. The stub is dead code at runtime: the board devicetree defines no pinctrl states, so the UART driver's `pinctrl_apply_state()` call returns -ENOENT, which it explicitly tolerates.

Verified by building the zephyr+baremetal demo for mps3-an536.
